### PR TITLE
U4ID tunnel source updates

### DIFF
--- a/include/net/xia_fib.h
+++ b/include/net/xia_fib.h
@@ -27,7 +27,7 @@ struct xia_fib_config {
 	/* See rtm_type in linux/rtnetlink.h */
 	u8			xfc_type;
 	u8			xfc_lladdr_len;
-	/* 1 byte unused */
+	u8			xfc_protoinfo_len;
 
 	u32			xfc_flags;
 
@@ -35,6 +35,7 @@ struct xia_fib_config {
 	struct net_device	*xfc_odev;
 	struct xia_xid		*xfc_gw;
 	u8			*xfc_lladdr;
+	void			*xfc_protoinfo;
 
 	u32			xfc_nlflags;
 	struct nl_info		xfc_nlinfo;

--- a/include/net/xia_u4id.h
+++ b/include/net/xia_u4id.h
@@ -1,0 +1,6 @@
+#ifndef _NET_XIA_U4ID_H
+#define _NET_XIA_U4ID_H
+
+#define XIDTYPE_U4ID            (__cpu_to_be32(0x16))
+
+#endif	/* _NET_XIA_U4ID_H */

--- a/include/net/xia_u4id.h
+++ b/include/net/xia_u4id.h
@@ -1,6 +1,15 @@
 #ifndef _NET_XIA_U4ID_H
 #define _NET_XIA_U4ID_H
 
+#ifndef __KERNEL__
+#include <stdbool.h>
+#endif
+
 #define XIDTYPE_U4ID            (__cpu_to_be32(0x16))
+
+struct local_u4id_info {
+	bool	tunnel;
+	bool	checksum_disabled;
+};
 
 #endif	/* _NET_XIA_U4ID_H */

--- a/include/uapi/linux/rtnetlink.h
+++ b/include/uapi/linux/rtnetlink.h
@@ -289,7 +289,7 @@ enum rtattr_type_t {
 	RTA_PREFSRC,
 	RTA_METRICS,
 	RTA_MULTIPATH,
-	RTA_PROTOINFO, /* no longer used */
+	RTA_PROTOINFO, /* Only used by XIA */
 	RTA_FLOW,
 	RTA_CACHEINFO,
 	RTA_SESSION, /* no longer used */

--- a/net/xia/ppal_u4id/main.c
+++ b/net/xia/ppal_u4id/main.c
@@ -7,10 +7,9 @@
 #include <net/xia_dag.h>
 #include <net/xia_fib.h>
 #include <net/xia_output.h>
+#include <net/xia_u4id.h>
 #include <net/xia_vxidty.h>
 #include <uapi/linux/udp.h>
-
-#define XIDTYPE_U4ID		(__cpu_to_be32(0x16))
 
 /*
  *	U4ID context

--- a/net/xia/ppal_u4id/main.c
+++ b/net/xia/ppal_u4id/main.c
@@ -398,9 +398,6 @@ static struct pernet_operations u4id_net_ops __read_mostly = {
  *	U4ID Routing
  */
 
-
-typedef void (*dst_destroy_method_t)(struct dst_entry *dst);
-
 /* Tunnel destination information held in a DST entry. */
 struct u4id_tunnel_dest {
 	__be32	dest_ip_addr;

--- a/net/xia/ppal_uni4id/main.c
+++ b/net/xia/ppal_uni4id/main.c
@@ -2,6 +2,7 @@
 #include <net/xia_fib.h>
 #include <net/xia_route.h>
 #include <net/xia_dag.h>
+#include <net/xia_u4id.h>
 #include <net/xia_vxidty.h>
 
 /* United 4ID Principal */
@@ -85,13 +86,11 @@ static struct pernet_operations uni4id_net_ops __read_mostly = {
  *	United 4ID Routing
  */
 
-/* XXX The following XID types should come from their respective
- * principals' header files once they are available.
+/* XXX The following XID type should come from its
+ * principal's header file once it is available.
  */
 /* IP 4ID: XIP over IP. */
 #define XIDTYPE_I4ID (__cpu_to_be32(0x15))
-/* UDP 4ID: XIP over UDP. */
-#define XIDTYPE_U4ID (__cpu_to_be32(0x16))
 
 static const u8 uni_xid_prefix[] = {
 	/* 0     1     2     3     4     5     6     7 */


### PR DESCRIPTION
This patch removes the previous notion of a tunnel socket and make one of the local entry sockets be the source of the tunnel.
