### PR TITLE
U4ID socket creation/checksumming updates

### DIFF
--- a/include/net/xia_u4id.h
+++ b/include/net/xia_u4id.h
@@ -9,7 +9,7 @@
 
 struct local_u4id_info {
 	bool	tunnel;
-	bool	checksum_disabled;
+	bool	no_check;
 };
 
 #endif	/* _NET_XIA_U4ID_H */


### PR DESCRIPTION
These patches clean up the U4ID code and use new, general-purpose functions to create UDP sockets and calculate UDP checksums.
