### PR TITLE
Style fixes in XIA code

### DIFF
--- a/include/net/xia.h
+++ b/include/net/xia.h
@@ -41,6 +41,7 @@ static inline int are_xids_equal(const __u8 *xid1, const __u8 *xid2)
 {
 	const __u32 *n1 = (const __u32 *)xid1;
 	const __u32 *n2 = (const __u32 *)xid2;
+
 	BUILD_BUG_ON(XIA_XID_MAX != sizeof(const __u32) * 5);
 	return	n1[0] == n2[0] &&
 		n1[1] == n2[1] &&
@@ -54,6 +55,7 @@ static inline int are_sxids_equal(const struct xia_xid *xid1,
 {
 	const __u64 *n1 = (const __u64 *)xid1;
 	const __u64 *n2 = (const __u64 *)xid2;
+
 	BUILD_BUG_ON(sizeof(struct xia_xid) != sizeof(const __u64) * 3);
 	return	n1[0] == n2[0] &&
 		n1[1] == n2[1] &&
@@ -140,6 +142,7 @@ static inline int xia_is_nat(xid_type_t ty)
 static inline void unmark_xia_addr(struct xia_addr *addr)
 {
 	int i;
+
 	for (i = 0; i < XIA_NODES_MAX; i++)
 		addr->s_row[i].s_edge.i &= ~XIA_CHOSEN_EDGES;
 }
@@ -147,6 +150,7 @@ static inline void unmark_xia_addr(struct xia_addr *addr)
 static inline void unmark_xia_rows(struct xia_row *addr, unsigned int n)
 {
 	unsigned int i;
+
 	BUG_ON(n >= XIA_NODES_MAX);
 	for (i = 0; i < n; i++)
 		addr[i].s_edge.i &= ~XIA_CHOSEN_EDGES;

--- a/include/net/xia_fib.h
+++ b/include/net/xia_fib.h
@@ -60,7 +60,7 @@ struct fib_xid {
 
 	/* Type of this entry.
 	 * This type field is meant to help principals to have different
-	 * kinds of entries in a same XID tabel. 
+	 * kinds of entries in a same XID tabel.
 	 */
 	u8			fx_entry_type;
 
@@ -177,7 +177,7 @@ typedef struct xia_ppal_rt_eops xia_ppal_all_rt_eops_t[XRTABLE_MAX_INDEX];
 
 /* This function is meant to help writing functions for field newroute of
  * struct xia_ppal_rt_eops. It deals with NLM_F_* flags and flushes negative
- * anchors when a new entry is added. 
+ * anchors when a new entry is added.
  *
  * IMPORTANT
  *	This function may sleep.

--- a/include/net/xia_hid.h
+++ b/include/net/xia_hid.h
@@ -44,7 +44,7 @@ struct xip_hid_ctx {
 	/* Simplify scanning network devices. */
 	struct net		*net;
 
- 	/* NWP's state per struct net. */
+	/* NWP's state per struct net. */
 	atomic_t	to_announce;
 	atomic_t	announced;
 	atomic_t	me; /* Number of local HIDs in ctx.xpc_xtbl. */

--- a/include/net/xia_serval.h
+++ b/include/net/xia_serval.h
@@ -74,7 +74,7 @@ enum {
 
 struct serval_rt_id {
 	struct fib_xid			fxid;
-	struct xip_dst_anchor   	anchor;
+	struct xip_dst_anchor		anchor;
 	struct serval_sock __rcu	*ssk;
 };
 

--- a/include/net/xia_vxidty.h
+++ b/include/net/xia_vxidty.h
@@ -57,6 +57,7 @@ static inline int xt_to_vxt_rcu(xid_type_t ty)
 static inline int xt_to_vxt(xid_type_t ty)
 {
 	int ret;
+
 	rcu_read_lock();
 	ret = xt_to_vxt_rcu(ty);
 	rcu_read_unlock();

--- a/net/xia/dag.c
+++ b/net/xia/dag.c
@@ -17,9 +17,7 @@
 
 #include "dag_userland.h"
 
-/*
- *	Map beween principal names and numbers
- */
+/* Map beween principal names and numbers */
 
 struct ppal_node {
 	struct hlist_node	lst_per_name;
@@ -204,9 +202,7 @@ int ppal_del_map(xid_type_t type)
 }
 EXPORT_SYMBOL(ppal_del_map);
 
-/*
- *	Validating addresses
- */
+/* Validating addresses */
 
 int xia_are_edges_valid(const struct xia_row *row,
 			__u8 node, __u8 num_node, __u32 *pvisited)
@@ -303,9 +299,7 @@ int xia_test_addr(const struct xia_addr *addr)
 }
 EXPORT_SYMBOL(xia_test_addr);
 
-/*
- *	Printing addresses out
- */
+/* Printing addresses out */
 
 #define INDEX_BASE 36
 static inline char edge_to_char(__u8 e)
@@ -494,9 +488,7 @@ int xia_ntop(const struct xia_addr *src, char *dst, size_t dstlen,
 }
 EXPORT_SYMBOL(xia_ntop);
 
-/*
- *	xia_pton and its auxiliares functions
- */
+/* xia_pton and its auxiliares functions */
 
 static inline void next(const char **pp, size_t *pleft)
 {

--- a/net/xia/dag.c
+++ b/net/xia/dag.c
@@ -44,6 +44,7 @@ static __u32 djb_case_hash(const char *str)
 	 * Notice that this function expects that chars are unsigned.
 	 */
 	const __u8 *p = (const __u8 *)str;
+
 	while (*p) {
 		hash = ((hash << 5) + hash) + tolower(*p);
 		p++;
@@ -233,6 +234,7 @@ int xia_are_edges_valid(const struct xia_row *row,
 	bits = 0xffffffff;
 	for (i = 0; i < XIA_OUTDEGREE_MAX; i++, edge++) {
 		__u8 e = *edge;
+
 		if (e == XIA_EMPTY_EDGE) {
 			if ((all_edges & bits) !=
 				(XIA_EMPTY_EDGES & bits))
@@ -265,6 +267,7 @@ int xia_test_addr(const struct xia_addr *addr)
 	n = XIA_NODES_MAX;
 	for (i = 0; i < XIA_NODES_MAX; i++) {
 		xid_type_t ty = addr->s_row[i].s_xid.xid_type;
+
 		if (saw_nat) {
 			if (!xia_is_nat(ty))
 				return -XIAEADDR_NAT_MISPLACED;
@@ -278,6 +281,7 @@ int xia_test_addr(const struct xia_addr *addr)
 	/* Test edges are well formed. */
 	for (i = 0; i < n; i++) {
 		int rc = xia_are_edges_valid(&addr->s_row[i], i, n, &visited);
+
 		if (rc)
 			return rc;
 	}
@@ -287,6 +291,7 @@ int xia_test_addr(const struct xia_addr *addr)
 		 * friendlier error since it's also XIAEADDR_MULTI_COMPONENTS.
 		 */
 		__be32 all_edges = addr->s_row[n - 1].s_edge.i;
+
 		if (__be32_to_raw_cpu(all_edges) == XIA_EMPTY_EDGES)
 			return -XIAEADDR_NO_ENTRY;
 
@@ -328,6 +333,7 @@ static inline int su_ge(signed int s, unsigned int u)
 static inline int add_str(char *dst, size_t dstlen, char *s)
 {
 	int rc = snprintf(dst, dstlen, "%s", s);
+
 	if (su_ge(rc, dstlen))
 		return -ENOSPC;
 	return rc;
@@ -391,6 +397,7 @@ int xia_tytop(xid_type_t ty, char *dst, size_t dstlen)
 	if (ppal_type_to_name(ty, dst)) {
 		/* Number format. */
 		int rc = snprintf(dst, dstlen, "0x%x", __be32_to_cpu(ty));
+
 		BUILD_BUG_ON(sizeof(xid_type_t) != 4);
 		if (su_ge(rc, dstlen))
 			return -ENOSPC;
@@ -507,6 +514,7 @@ static inline int read_sep(const char **pp, size_t *pleft, char sep)
 static int read_invalid_flag(const char **pp, size_t *pleft, int *invalid_flag)
 {
 	int inv_flag;
+
 	if (*pleft <= 0) /* No XIA address is an empty string. */
 		return -1;
 	inv_flag = **pp == '!';
@@ -565,6 +573,7 @@ static int read_name(const char **pp, size_t *pleft, char *name, int len)
 static int read_0x(const char **pp, size_t *pleft)
 {
 	char ch1, ch2;
+
 	if (*pleft < 2)
 		return -1;
 	ch1 = (*pp)[0];
@@ -585,6 +594,7 @@ static int read_type(const char **pp, size_t *pleft, xid_type_t *pty)
 	if (read_0x(pp, pleft) < 0) {
 		/* It must be a name. */
 		char name[MAX_PPAL_NAME_SIZE];
+
 		if (read_name(pp, pleft, name, sizeof(name)) < 0)
 			return -1;
 		/* One does not need to test if @name is valid here because
@@ -607,6 +617,7 @@ static int read_xid(const char **pp, size_t *pleft, __u8 *xid)
 {
 	int i;
 	__be32 *pxid = (__be32 *)xid;
+
 	BUILD_BUG_ON(XIA_XID_MAX != 20);
 
 	for (i = 0; i < 5; i++) {

--- a/net/xia/dag.c
+++ b/net/xia/dag.c
@@ -402,8 +402,9 @@ int xia_tytop(xid_type_t ty, char *dst, size_t dstlen)
 		if (su_ge(rc, dstlen))
 			return -ENOSPC;
 		return rc;
-	} else
+	} else {
 		return strlen(dst);
+	}
 }
 EXPORT_SYMBOL(xia_tytop);
 

--- a/net/xia/dag.c
+++ b/net/xia/dag.c
@@ -209,7 +209,7 @@ EXPORT_SYMBOL(ppal_del_map);
  */
 
 int xia_are_edges_valid(const struct xia_row *row,
-	__u8 node, __u8 num_node, __u32 *pvisited)
+			__u8 node, __u8 num_node, __u32 *pvisited)
 {
 	const __u8 *edge;
 	__u32 all_edges, bits;
@@ -445,7 +445,7 @@ int xia_xidtop(const struct xia_xid *src, char *dst, size_t dstlen)
 EXPORT_SYMBOL(xia_xidtop);
 
 int xia_ntop(const struct xia_addr *src, char *dst, size_t dstlen,
-	int include_nl)
+	     int include_nl)
 {
 	int tot = 0;
 	char *node_sep = include_nl ? ":\n" : ":";
@@ -618,7 +618,7 @@ static int read_xid(const char **pp, size_t *pleft, __u8 *xid)
 }
 
 static int read_edges(const char **pp, size_t *pleft, __u8 *edges,
-	int ignore_ce)
+		      int ignore_ce)
 {
 	int i;
 
@@ -656,7 +656,7 @@ static int read_edges(const char **pp, size_t *pleft, __u8 *edges,
 }
 
 static int read_row(const char **pp, size_t *pleft, struct xia_row *row,
-	int ignore_ce)
+		    int ignore_ce)
 {
 	if (read_type(pp, pleft, &row->s_xid.xid_type))
 		return -1;
@@ -678,7 +678,7 @@ static int read_node_sep(const char **pp, size_t *pleft)
 }
 
 int xia_pton(const char *src, size_t srclen, struct xia_addr *dst,
-	int ignore_ce, int *invalid_flag)
+	     int ignore_ce, int *invalid_flag)
 {
 	const char *p = src;
 	size_t left = srclen;

--- a/net/xia/dag.c
+++ b/net/xia/dag.c
@@ -3,8 +3,7 @@
 #include <net/xia_fib.h>
 #include <net/xia_dag.h>
 
-/*
- * IMPORTANT
+/* IMPORTANT
  *
  * This file is intended to be used by userland applications without editing!
  *
@@ -19,7 +18,7 @@
 #include "dag_userland.h"
 
 /*
- * Map beween principal names and numbers
+ *	Map beween principal names and numbers
  */
 
 struct ppal_node {
@@ -205,7 +204,7 @@ int ppal_del_map(xid_type_t type)
 EXPORT_SYMBOL(ppal_del_map);
 
 /*
- * Validating addresses
+ *	Validating addresses
  */
 
 int xia_are_edges_valid(const struct xia_row *row,
@@ -300,7 +299,7 @@ int xia_test_addr(const struct xia_addr *addr)
 EXPORT_SYMBOL(xia_test_addr);
 
 /*
- * Printing addresses out
+ *	Printing addresses out
  */
 
 #define INDEX_BASE 36
@@ -488,7 +487,7 @@ int xia_ntop(const struct xia_addr *src, char *dst, size_t dstlen,
 EXPORT_SYMBOL(xia_ntop);
 
 /*
- * xia_pton and its auxiliares functions
+ *	xia_pton and its auxiliares functions
  */
 
 static inline void next(const char **pp, size_t *pleft)

--- a/net/xia/dag_userland.h
+++ b/net/xia/dag_userland.h
@@ -50,12 +50,14 @@ struct hlist_node {
 static inline void hlist_add_head(struct hlist_node *n, struct hlist_head *h)
 {
 	struct hlist_node *first = h->first;
+
 	n->next = first;
 	if (first)
 		first->pprev = &n->next;
 	h->first = n;
 	n->pprev = &h->first;
 }
+
 #define hlist_add_head_rcu	hlist_add_head
 
 static inline void __hlist_del(struct hlist_node *n)
@@ -75,6 +77,7 @@ static inline void hlist_del(struct hlist_node *n)
 	n->next = LIST_POISON1;
 	n->pprev = LIST_POISON2;
 }
+
 #define hlist_del_rcu		hlist_del
 
 #define mymalloc(n)	malloc(n)

--- a/net/xia/dag_userland.h
+++ b/net/xia/dag_userland.h
@@ -27,11 +27,11 @@ struct hlist_node {
 #ifdef __compiler_offsetof
 #define offsetof(TYPE, MEMBER) __compiler_offsetof(TYPE, MEMBER)
 #else
-#define offsetof(TYPE, MEMBER) ((size_t) &((TYPE *)0)->MEMBER)
+#define offsetof(TYPE, MEMBER) ((size_t)&((TYPE *)0)->MEMBER)
 #endif
 
 #define container_of(ptr, type, member) ({			\
-	const typeof(((type *)0)->member) *__mptr = (ptr);	\
+	const typeof(((type *)0)->member)*__mptr = (ptr);	\
 	(type *)((char *)__mptr - offsetof(type, member)); })
 
 #define hlist_entry(ptr, type, member) container_of(ptr, type, member)

--- a/net/xia/fib.c
+++ b/net/xia/fib.c
@@ -384,7 +384,6 @@ static inline u32 fib_lock_bucket(struct fib_xid_table *xtbl,
 void fib_unlock_bucket(struct fib_xid_table *xtbl, u32 bucket)
 	__releases(xip_bucket_lock)
 {
-
 	/* Make sparse happy with only one __releases. */
 	__acquire(bucket);
 

--- a/net/xia/fib.c
+++ b/net/xia/fib.c
@@ -5,9 +5,7 @@
 #include <net/xia_vxidty.h>
 #include <net/xia_fib.h>
 
-/*
- *	Lock tables
- */
+/* Lock tables */
 
 static inline u32 xtbl_hash_mix(struct fib_xid_table *xtbl)
 {
@@ -40,9 +38,7 @@ static void bucket_unlock(struct fib_xid_table *xtbl, u32 bucket)
 	xia_lock_table_unlock(xtbl->fxt_locktbl, hash_bucket(xtbl, bucket));
 }
 
-/*
- *	Principal context
- */
+/* Principal context */
 
 int init_fib_ppal_ctx(struct net *net)
 {
@@ -117,9 +113,7 @@ struct xip_ppal_ctx *xip_find_ppal_ctx_rcu(struct net *net, xid_type_t ty)
 }
 EXPORT_SYMBOL_GPL(xip_find_ppal_ctx_rcu);
 
-/*
- *	Routing tables
- */
+/* Routing tables */
 
 /* This function must be called in process context due to virtual memory. */
 static int alloc_buckets(struct fib_xid_buckets *branch, size_t num)
@@ -802,9 +796,7 @@ def_upd:
 }
 EXPORT_SYMBOL_GPL(fib_build_newroute);
 
-/*
- *	Main entries that only redirect.
- */
+/* Main entries that only redirect */
 
 struct fib_xid_redirect_main {
 	struct fib_xid		common;

--- a/net/xia/fib.c
+++ b/net/xia/fib.c
@@ -87,7 +87,7 @@ int xip_add_ppal_ctx(struct net *net, struct xip_ppal_ctx *ctx)
 		return -EEXIST;
 	}
 	rcu_assign_pointer(net->xia.fib_ctx[vxt], ctx);
-		
+
 	return 0;
 }
 EXPORT_SYMBOL_GPL(xip_add_ppal_ctx);

--- a/net/xia/fib_frontend.c
+++ b/net/xia/fib_frontend.c
@@ -150,8 +150,8 @@ static inline void clear_cb_from(struct netlink_callback *cb, int from)
 }
 
 static int xia_fib_dump_xtbl_rcu(struct fib_xid_table *xtbl,
-	struct xip_ppal_ctx *ctx, struct sk_buff *skb,
-	struct netlink_callback *cb)
+				 struct xip_ppal_ctx *ctx, struct sk_buff *skb,
+				 struct netlink_callback *cb)
 {
 	struct fib_xid_buckets *abranch;
 	long i, j = 0;
@@ -167,7 +167,7 @@ static int xia_fib_dump_xtbl_rcu(struct fib_xid_table *xtbl,
 		struct hlist_head *head = &abranch->buckets[i];
 		j = 0;
 		hlist_for_each_entry_rcu(fxid, head,
-			fx_branch_list[aindex]) {
+					 fx_branch_list[aindex]) {
 			if (j < first_j)
 				goto next;
 			rc = xtbl->all_eops[fxid->fx_table_id].dump_fxid(
@@ -210,7 +210,7 @@ static int xip_fib_dump_ppals(struct sk_buff *skb, struct netlink_callback *cb)
 }
 
 static int xip_dst_dump_entry(struct xip_dst *xdst, struct sk_buff *skb,
-	struct netlink_callback *cb)
+			      struct netlink_callback *cb)
 {
 #define SIZE_OF_DEST	(sizeof(struct xia_xid[XIA_OUTDEGREE_MAX]))
 
@@ -221,7 +221,7 @@ static int xip_dst_dump_entry(struct xip_dst *xdst, struct sk_buff *skb,
 	struct xip_dst_cachinfo ci;
 
 	nlh = nlmsg_put(skb, portid, seq, RTM_NEWROUTE, sizeof(*rtm),
-		NLM_F_MULTI);
+			NLM_F_MULTI);
 	if (nlh == NULL)
 		return -EMSGSIZE;
 
@@ -250,7 +250,7 @@ static int xip_dst_dump_entry(struct xip_dst *xdst, struct sk_buff *skb,
 	ci.chosen_edge =xdst->chosen_edge;
 
 	if (unlikely(nla_put(skb, RTA_PROTOINFO,
-		sizeof(struct xip_dst_cachinfo), &ci)))
+			     sizeof(struct xip_dst_cachinfo), &ci)))
 		goto nla_put_failure;
 
 	return nlmsg_end(skb, nlh);

--- a/net/xia/fib_frontend.c
+++ b/net/xia/fib_frontend.c
@@ -136,6 +136,7 @@ static int xip_rtm_delroute(struct sk_buff *skb, struct nlmsghdr *nlh)
 {
 	if (is_cloned(nlh)) {
 		struct net *net = sock_net(skb->sk);
+
 		clear_xdst_table(net);
 		return 0;
 	}
@@ -165,6 +166,7 @@ static int xia_fib_dump_xtbl_rcu(struct fib_xid_table *xtbl,
 	for (i = cb->args[1]; i < divisor; i++, first_j = 0) {
 		struct fib_xid *fxid;
 		struct hlist_head *head = &abranch->buckets[i];
+
 		j = 0;
 		hlist_for_each_entry_rcu(fxid, head,
 					 fx_branch_list[aindex]) {
@@ -195,6 +197,7 @@ static int xip_fib_dump_ppals(struct sk_buff *skb, struct netlink_callback *cb)
 	rcu_read_lock();
 	for (i = cb->args[0]; i < XIP_MAX_XID_TYPES; i++) {
 		struct xip_ppal_ctx *ctx = xip_find_ppal_ctx_vxt_rcu(net, i);
+
 		if (!ctx || !ctx->xpc_xtbl)
 			continue;
 		if (dumped)
@@ -270,6 +273,7 @@ static int xip_dst_dump(struct sk_buff *skb, struct netlink_callback *cb)
 
 	for (i = cb->args[0]; i < XIP_DST_TABLE_SIZE; i++, first_j = 0) {
 		struct dst_entry *dsth;
+
 		j = 0;
 		rcu_read_lock();
 		for (dsth = rcu_dereference(net->xia.xip_dst_table.buckets[i]);

--- a/net/xia/fib_frontend.c
+++ b/net/xia/fib_frontend.c
@@ -305,9 +305,7 @@ static int xip_dump_fib(struct sk_buff *skb, struct netlink_callback *cb)
 	return xip_fib_dump_ppals(skb, cb);
 }
 
-/*
- *	Network namespace
- */
+/* Network namespace */
 
 static int __net_init fib_net_init(struct net *net)
 {

--- a/net/xia/fib_frontend.c
+++ b/net/xia/fib_frontend.c
@@ -5,7 +5,7 @@
 #include <net/xia_fib.h>
 #include <net/xia_route.h>
 
-#define FIELD_TYPE(t,f)		typeof(((struct t *)0)->f)
+#define FIELD_TYPE(t, f)	typeof(((struct t *)0)->f)
 
 #define XID_NLATTR		{ .len = sizeof(struct xia_xid) }
 #define PROTOINFO_NLATTR	{					\
@@ -250,7 +250,7 @@ static int xip_dst_dump_entry(struct xip_dst *xdst, struct sk_buff *skb,
 	ci.input = xdst->input;
 	ci.passthrough_action = xdst->passthrough_action;
 	ci.sink_action = xdst->sink_action;
-	ci.chosen_edge =xdst->chosen_edge;
+	ci.chosen_edge = xdst->chosen_edge;
 
 	if (unlikely(nla_put(skb, RTA_PROTOINFO,
 			     sizeof(struct xip_dst_cachinfo), &ci)))

--- a/net/xia/locktbl.c
+++ b/net/xia/locktbl.c
@@ -7,7 +7,7 @@ int xia_lock_table_init(struct xia_lock_table *lock_table, int spread)
 	int cpus = num_possible_cpus();
 	int i, nlocks;
 	size_t size;
-	spinlock_t *locks;
+	spinlock_t *locks;	/* Table locks. */
 
 	BUG_ON(cpus <= 0);
 	nlocks = roundup_pow_of_two(cpus * spread);

--- a/net/xia/main.c
+++ b/net/xia/main.c
@@ -11,8 +11,7 @@
 #include <linux/module.h>
 #include <net/xia_dag.h>
 
-/*
- * Initialization functions
+/* Initialization functions
  *
  * These functions are defined in other files, but they are only used here.
  */
@@ -30,11 +29,10 @@ int xia_socket_init(void);
 void xia_socket_exit(void);
 
 /*
- * Main
+ *	Main
  */
 
-/*
- * xia_init - this function is called when the module is loaded.
+/* xia_init - this function is called when the module is loaded.
  * Returns zero if successfully loaded, nonzero otherwise.
  */
 static int __init xia_init(void)
@@ -83,9 +81,7 @@ out:
 	return rc;
 }
 
-/*
- * xia_exit - this function is called when the modlule is removed.
- */
+/* xia_exit - this function is called when the modlule is removed. */
 static void __exit xia_exit(void)
 {
 	xia_socket_exit();

--- a/net/xia/main.c
+++ b/net/xia/main.c
@@ -28,9 +28,7 @@ void xip_route_exit(void);
 int xia_socket_init(void);
 void xia_socket_exit(void);
 
-/*
- *	Main
- */
+/* Main */
 
 /* xia_init - this function is called when the module is loaded.
  * Returns zero if successfully loaded, nonzero otherwise.

--- a/net/xia/output.c
+++ b/net/xia/output.c
@@ -162,7 +162,7 @@ static struct sk_buff *__xip_start_skb(struct sock *sk, struct xip_dst *xdst,
 	skb_put(skb, transhdrlen);
 
 	/* XXX Does we need to set skb_shinfo(skb)->tx_flags? */
-	
+
 	skb->priority = sk->sk_priority;
 	skb->mark = sk->sk_mark;
 	xdst_hold(xdst);

--- a/net/xia/output.c
+++ b/net/xia/output.c
@@ -7,6 +7,7 @@ int __xip_local_out(struct sk_buff *skb)
 {
 	struct xiphdr *xiph = xip_hdr(skb);
 	int len = skb->len - xip_hdr_len(xiph);
+
 	BUG_ON(len < 0);
 	BUG_ON(len > XIP_MAXPLEN);
 	xiph->payload_len = cpu_to_be16(len);
@@ -44,6 +45,7 @@ static inline void copy_xia_addr_to(const struct xia_row *addr, int n,
 				    struct xia_row *to)
 {
 	int len = sizeof(struct xia_row) * n;
+
 	BUG_ON(n < 0 || n > XIA_NODES_MAX);
 	memmove(to, addr, len);
 }
@@ -52,6 +54,7 @@ void xip_flush_pending_frames(struct sock *sk)
 {
 	struct sk_buff_head *queue = &sk->sk_write_queue;
 	struct sk_buff *skb;
+
 	while ((skb = __skb_dequeue_tail(queue)) != NULL)
 		kfree_skb(skb);
 }
@@ -74,6 +77,7 @@ static inline struct xia_row *__xip_fill_in_hdr(struct sk_buff *skb,
 	int dest_n, int dest_last_node)
 {
 	struct xiphdr *xiph = xip_hdr(skb);
+
 	BUG_ON(dest_n < 1);
 	xiph->version = 1;
 	xiph->next_hdr = 0;
@@ -94,6 +98,7 @@ void xip_fill_in_hdr_bsrc(struct sk_buff *skb, struct xip_dst *xdst,
 	struct xia_row *src_row = __xip_fill_in_hdr(skb, xdst, src_n,
 		dest, dest_n, dest_last_node);
 	int last = src_n - 1;
+
 	BUG_ON(src_n < 1);
 	copy_xia_addr_to(src,  last,  src_row);
 	src_row[last].s_xid.xid_type = sink_type;

--- a/net/xia/output.c
+++ b/net/xia/output.c
@@ -41,7 +41,7 @@ struct sk_buff *xip_trim_packet_if_needed(struct sk_buff *skb, u32 mtu)
 EXPORT_SYMBOL_GPL(xip_trim_packet_if_needed);
 
 static inline void copy_xia_addr_to(const struct xia_row *addr, int n,
-	struct xia_row *to)
+				    struct xia_row *to)
 {
 	int len = sizeof(struct xia_row) * n;
 	BUG_ON(n < 0 || n > XIA_NODES_MAX);
@@ -86,8 +86,10 @@ static inline struct xia_row *__xip_fill_in_hdr(struct sk_buff *skb,
 }
 
 void xip_fill_in_hdr_bsrc(struct sk_buff *skb, struct xip_dst *xdst,
-	const struct xia_row *src, xid_type_t sink_type, const __u8 *sink_id,
-	int src_n, const struct xia_row *dest, int dest_n, int dest_last_node)
+			  const struct xia_row *src, xid_type_t sink_type,
+			  const __u8 *sink_id, int src_n,
+			  const struct xia_row *dest, int dest_n,
+			  int dest_last_node)
 {
 	struct xia_row *src_row = __xip_fill_in_hdr(skb, xdst, src_n,
 		dest, dest_n, dest_last_node);
@@ -101,8 +103,9 @@ void xip_fill_in_hdr_bsrc(struct sk_buff *skb, struct xip_dst *xdst,
 EXPORT_SYMBOL_GPL(xip_fill_in_hdr_bsrc);
 
 void xip_fill_in_hdr(struct sk_buff *skb, struct xip_dst *xdst,
-	const struct xia_row *src, int src_n,
-	const struct xia_row *dest, int dest_n, int dest_last_node)
+		     const struct xia_row *src, int src_n,
+		     const struct xia_row *dest, int dest_n,
+		     int dest_last_node)
 {
 	struct xia_row *src_row = __xip_fill_in_hdr(skb, xdst, src_n,
 		dest, dest_n, dest_last_node);
@@ -111,9 +114,8 @@ void xip_fill_in_hdr(struct sk_buff *skb, struct xip_dst *xdst,
 EXPORT_SYMBOL_GPL(xip_fill_in_hdr);
 
 static struct sk_buff *__xip_start_skb(struct sock *sk, struct xip_dst *xdst,
-	const struct xia_addr *src, int src_n,
-	const struct xia_addr *dest, int dest_n, u8 dest_last_node,
-	int transhdrlen, int noblock)
+	const struct xia_addr *src, int src_n, const struct xia_addr *dest,
+	int dest_n, u8 dest_last_node, int transhdrlen, int noblock)
 {
 	struct net_device *dev = xdst->dst.dev;
 	struct sk_buff *skb;
@@ -122,14 +124,14 @@ static struct sk_buff *__xip_start_skb(struct sock *sk, struct xip_dst *xdst,
 
 	if (!dev) {
 		LIMIT_NETDEBUG(KERN_WARNING pr_fmt("XIP %s: there is a bug somewhere, tried to send a datagram, but dst.dev is NULL\n"),
-			__func__);
+			       __func__);
 		return ERR_PTR(-ENODEV);
 	}
 
 	mtu = dst_mtu(&xdst->dst);
 	if (mtu < XIP_MIN_MTU) {
 		LIMIT_NETDEBUG(KERN_WARNING pr_fmt("XIP %s: cannot send datagram out because mtu (= %u) of dev %s is less than minimum MTU (= %u)\n"),
-			__func__, mtu, dev->name, XIP_MIN_MTU);
+			       __func__, mtu, dev->name, XIP_MIN_MTU);
 		return ERR_PTR(-EMSGSIZE);
 	}
 
@@ -149,7 +151,7 @@ static struct sk_buff *__xip_start_skb(struct sock *sk, struct xip_dst *xdst,
 	xh_len = xip_hdr_size(dest_n, src_n);
 	skb_put(skb, xh_len);
 	xip_fill_in_hdr(skb, xdst, src->s_row, src_n,
-		dest->s_row, dest_n, dest_last_node);
+			dest->s_row, dest_n, dest_last_node);
 
 	skb_set_transport_header(skb, xh_len);
 	skb_put(skb, transhdrlen);
@@ -165,7 +167,7 @@ static struct sk_buff *__xip_start_skb(struct sock *sk, struct xip_dst *xdst,
 
 static int __xip_append_data(struct sk_buff *skb,
 	int getfrag(void *from, char *to, int offset,
-		int len, int odd, struct sk_buff *skb),
+		    int len, int odd, struct sk_buff *skb),
 	struct iovec *from, int length)
 {
 	int copy;
@@ -183,8 +185,8 @@ static int __xip_append_data(struct sk_buff *skb,
 }
 
 int xip_start_skb(struct sock *sk, struct xip_dst *xdst,
-	const struct xia_addr *dest, int dest_n, u8 dest_last_node,
-	int transhdrlen, unsigned int flags)
+		  const struct xia_addr *dest, int dest_n, u8 dest_last_node,
+		  int transhdrlen, unsigned int flags)
 {
 	struct xia_sock *xia = xia_sk(sk);
 	struct sk_buff *skb;
@@ -193,8 +195,8 @@ int xip_start_skb(struct sock *sk, struct xip_dst *xdst,
 		return -ESNOTBOUND;
 
 	skb = __xip_start_skb(sk, xdst, &xia->xia_saddr, xia->xia_snum,
-		dest, dest_n, dest_last_node, transhdrlen,
-		(flags & MSG_DONTWAIT));
+			      dest, dest_n, dest_last_node, transhdrlen,
+			      (flags & MSG_DONTWAIT));
 	if (IS_ERR(skb))
 		return PTR_ERR(skb);
 
@@ -207,7 +209,7 @@ EXPORT_SYMBOL_GPL(xip_start_skb);
 
 int xip_append_data(struct sock *sk,
 	int getfrag(void *from, char *to, int offset,
-		int len, int odd, struct sk_buff *skb),
+		    int len, int odd, struct sk_buff *skb),
 	struct iovec *from, int length, unsigned int flags)
 {
 	struct sk_buff *skb;
@@ -242,7 +244,7 @@ EXPORT_SYMBOL_GPL(xip_finish_skb);
 struct sk_buff *xip_make_skb(struct sock *sk,
 	const struct xia_addr *dest, int dest_n, u8 dest_last_node,
 	int getfrag(void *from, char *to, int offset,
-		int len, int odd, struct sk_buff *skb),
+		    int len, int odd, struct sk_buff *skb),
 	struct iovec *from, int length, int transhdrlen, struct xip_dst *xdst,
 	unsigned int flags)
 {
@@ -258,8 +260,8 @@ struct sk_buff *xip_make_skb(struct sock *sk,
 		return ERR_PTR(-ESNOTBOUND);
 
 	skb = __xip_start_skb(sk, xdst, &xia->xia_saddr, xia->xia_snum,
-		dest, dest_n, dest_last_node, transhdrlen,
-		(flags & MSG_DONTWAIT));
+			      dest, dest_n, dest_last_node, transhdrlen,
+			      (flags & MSG_DONTWAIT));
 	if (IS_ERR(skb))
 		return skb;
 

--- a/net/xia/ppal_ad/main.c
+++ b/net/xia/ppal_ad/main.c
@@ -111,6 +111,7 @@ nla_put_failure:
 static void local_free_ad(struct fib_xid_table *xtbl, struct fib_xid *fxid)
 {
 	struct fib_xid_ad_local *lad = fxid_lad(fxid);
+
 	xdst_free_anchor(&lad->anchor);
 	kfree(lad);
 }
@@ -133,6 +134,7 @@ static const xia_ppal_all_rt_eops_t ad_all_rt_eops = {
 static struct xip_ad_ctx *create_ad_ctx(void)
 {
 	struct xip_ad_ctx *ad_ctx = kmalloc(sizeof(*ad_ctx), GFP_KERNEL);
+
 	if (!ad_ctx)
 		return NULL;
 	xip_init_ppal_ctx(&ad_ctx->ctx, XIDTYPE_AD);
@@ -209,6 +211,7 @@ static int ad_deliver(struct xip_route_proc *rproc, struct net *net,
 	switch (fxid->fx_table_id) {
 	case XRTABLE_LOCAL_INDEX: {
 		struct fib_xid_ad_local *lad = fxid_lad(fxid);
+
 		xdst->passthrough_action = XDA_DIG;
 		xdst->sink_action = XDA_ERROR; /* An AD cannot be a sink. */
 		xdst_attach_to_anchor(xdst, anchor_index, &lad->anchor);

--- a/net/xia/ppal_ad/main.c
+++ b/net/xia/ppal_ad/main.c
@@ -7,9 +7,7 @@
 /* Autonomous Domain Principal */
 #define XIDTYPE_AD (__cpu_to_be32(0x10))
 
-/*
- *	AD context
- */
+/* AD context */
 
 struct xip_ad_ctx {
 	struct xip_ppal_ctx	ctx;
@@ -26,9 +24,7 @@ static inline struct xip_ad_ctx *ctx_ad(struct xip_ppal_ctx *ctx)
 
 static int my_vxt __read_mostly = -1;
 
-/*
- *	Local ADs
- */
+/* Local ADs */
 
 struct fib_xid_ad_local {
 	struct fib_xid		common;
@@ -127,9 +123,7 @@ static const xia_ppal_all_rt_eops_t ad_all_rt_eops = {
 	XIP_FIB_REDIRECT_MAIN,
 };
 
-/*
- *	Network namespace
- */
+/* Network namespace */
 
 static struct xip_ad_ctx *create_ad_ctx(void)
 {
@@ -187,9 +181,7 @@ static struct pernet_operations ad_net_ops __read_mostly = {
 	.exit = ad_net_exit,
 };
 
-/*
- *	AD Routing
- */
+/* AD Routing */
 
 static int ad_deliver(struct xip_route_proc *rproc, struct net *net,
 		      const u8 *xid, struct xia_xid *next_xid,

--- a/net/xia/ppal_ad/main.c
+++ b/net/xia/ppal_ad/main.c
@@ -223,7 +223,6 @@ static int ad_deliver(struct xip_route_proc *rproc, struct net *net,
 		fib_mrd_redirect(fxid, next_xid);
 		rcu_read_unlock();
 		return XRP_ACT_REDIRECT;
-
 	}
 	rcu_read_unlock();
 	BUG();

--- a/net/xia/ppal_ad/main.c
+++ b/net/xia/ppal_ad/main.c
@@ -231,8 +231,7 @@ static struct xip_route_proc ad_rt_proc __read_mostly = {
 	.deliver = ad_deliver,
 };
 
-/*
- * xia_ad_init - this function is called when the module is loaded.
+/* xia_ad_init - this function is called when the module is loaded.
  * Returns zero if successfully loaded, nonzero otherwise.
  */
 static int __init xia_ad_init(void)
@@ -271,9 +270,7 @@ out:
 	return rc;
 }
 
-/*
- * xia_ad_exit - this function is called when the modlule is removed.
- */
+/* xia_ad_exit - this function is called when the modlule is removed. */
 static void __exit xia_ad_exit(void)
 {
 	ppal_del_map(XIDTYPE_AD);

--- a/net/xia/ppal_ad/main.c
+++ b/net/xia/ppal_ad/main.c
@@ -44,7 +44,8 @@ static inline struct fib_xid_ad_local *fxid_lad(struct fib_xid *fxid)
 }
 
 static int local_newroute(struct xip_ppal_ctx *ctx,
-	struct fib_xid_table *xtbl, struct xia_fib_config *cfg)
+			  struct fib_xid_table *xtbl,
+			  struct xia_fib_config *cfg)
 {
 	struct fib_xid_ad_local *new_lad;
 	int rc;
@@ -53,7 +54,7 @@ static int local_newroute(struct xip_ppal_ctx *ctx,
 	if (!new_lad)
 		return -ENOMEM;
 	init_fxid(&new_lad->common, cfg->xfc_dst->xid_id,
-		XRTABLE_LOCAL_INDEX, 0);
+		  XRTABLE_LOCAL_INDEX, 0);
 	xdst_init_anchor(&new_lad->anchor);
 
 	rc = fib_build_newroute(&new_lad->common, xtbl, cfg, NULL);
@@ -66,8 +67,8 @@ static int local_newroute(struct xip_ppal_ctx *ctx,
  * net/ipv4/fib_trie.c:fn_trie_dump_fa.
  */
 static int local_dump_ad(struct fib_xid *fxid, struct fib_xid_table *xtbl,
-	struct xip_ppal_ctx *ctx, struct sk_buff *skb,
-	struct netlink_callback *cb)
+			 struct xip_ppal_ctx *ctx, struct sk_buff *skb,
+			 struct netlink_callback *cb)
 {
 	struct nlmsghdr *nlh;
 	u32 portid = NETLINK_CB(cb->skb).portid;
@@ -76,7 +77,7 @@ static int local_dump_ad(struct fib_xid *fxid, struct fib_xid_table *xtbl,
 	struct xia_xid dst;
 
 	nlh = nlmsg_put(skb, portid, seq, RTM_NEWROUTE, sizeof(*rtm),
-		NLM_F_MULTI);
+			NLM_F_MULTI);
 	if (nlh == NULL)
 		return -EMSGSIZE;
 
@@ -157,7 +158,7 @@ static int __net_init ad_net_init(struct net *net)
 	}
 
 	rc = init_xid_table(&ad_ctx->ctx, net, &xia_main_lock_table,
-		ad_all_rt_eops);
+			    ad_all_rt_eops);
 	if (rc)
 		goto ad_ctx;
 
@@ -189,8 +190,8 @@ static struct pernet_operations ad_net_ops __read_mostly = {
  */
 
 static int ad_deliver(struct xip_route_proc *rproc, struct net *net,
-	const u8 *xid, struct xia_xid *next_xid, int anchor_index,
-	struct xip_dst *xdst)
+		      const u8 *xid, struct xia_xid *next_xid,
+		      int anchor_index, struct xip_dst *xdst)
 {
 	struct xip_ppal_ctx *ctx;
 	struct fib_xid *fxid;

--- a/net/xia/ppal_hid/main.c
+++ b/net/xia/ppal_hid/main.c
@@ -485,7 +485,6 @@ static int hid_deliver(struct xip_route_proc *rproc, struct net *net,
 		rcu_read_unlock();
 		return XRP_ACT_FORWARD;
 	}
-
 	}
 	rcu_read_unlock();
 	BUG();

--- a/net/xia/ppal_hid/main.c
+++ b/net/xia/ppal_hid/main.c
@@ -46,6 +46,7 @@ static int local_newroute(struct xip_ppal_ctx *ctx,
 	rc = fib_build_newroute(&lhid->xhl_common, xtbl, cfg, &added);
 	if (!rc) {
 		struct xip_hid_ctx *hid_ctx = ctx_hid(ctx);
+
 		if (added)
 			atomic_inc(&hid_ctx->me);
 		atomic_inc(&hid_ctx->to_announce);
@@ -60,8 +61,10 @@ static int local_delroute(struct xip_ppal_ctx *ctx,
 			  struct xia_fib_config *cfg)
 {
 	int rc = fib_build_delroute(XRTABLE_LOCAL_INDEX, xtbl, cfg);
+
 	if (!rc) {
 		struct xip_hid_ctx *hid_ctx = ctx_hid(ctx);
+
 		atomic_dec(&hid_ctx->me);
 		/* XXX NWP should support negative announcements to speed up
 		 * detection of leaving HIDs.
@@ -116,6 +119,7 @@ nla_put_failure:
 static void local_free_hid(struct fib_xid_table *xtbl, struct fib_xid *fxid)
 {
 	struct fib_xid_hid_local *lhid = fxid_lhid(fxid);
+
 	xdst_free_anchor(&lhid->xhl_anchor);
 	kfree(lhid);
 }
@@ -240,6 +244,7 @@ static const xia_ppal_all_rt_eops_t hid_all_rt_eops = {
 static struct xip_hid_ctx *create_hid_ctx(struct net *net)
 {
 	struct xip_hid_ctx *hid_ctx = kmalloc(sizeof(*hid_ctx), GFP_KERNEL);
+
 	if (!hid_ctx)
 		return NULL;
 	xip_init_ppal_ctx(&hid_ctx->ctx, XIDTYPE_HID);
@@ -442,6 +447,7 @@ static int hid_deliver(struct xip_route_proc *rproc, struct net *net,
 	switch (fxid->fx_table_id) {
 	case XRTABLE_LOCAL_INDEX: {
 		struct fib_xid_hid_local *lhid = fxid_lhid(fxid);
+
 		xdst->passthrough_action = XDA_DIG;
 		xdst->sink_action = XDA_ERROR; /* An HID cannot be a sink. */
 		xdst_attach_to_anchor(xdst, anchor_index, &lhid->xhl_anchor);

--- a/net/xia/ppal_hid/main.c
+++ b/net/xia/ppal_hid/main.c
@@ -30,7 +30,8 @@ static inline struct fib_xid_hid_local *fxid_lhid(struct fib_xid *fxid)
 }
 
 static int local_newroute(struct xip_ppal_ctx *ctx,
-	struct fib_xid_table *xtbl, struct xia_fib_config *cfg)
+			  struct fib_xid_table *xtbl,
+			  struct xia_fib_config *cfg)
 {
 	struct fib_xid_hid_local *lhid;
 	int rc, added;
@@ -39,7 +40,7 @@ static int local_newroute(struct xip_ppal_ctx *ctx,
 	if (!lhid)
 		return -ENOMEM;
 	init_fxid(&lhid->xhl_common, cfg->xfc_dst->xid_id,
-		XRTABLE_LOCAL_INDEX, 0);
+		  XRTABLE_LOCAL_INDEX, 0);
 	xdst_init_anchor(&lhid->xhl_anchor);
 
 	rc = fib_build_newroute(&lhid->xhl_common, xtbl, cfg, &added);
@@ -55,7 +56,8 @@ static int local_newroute(struct xip_ppal_ctx *ctx,
 }
 
 static int local_delroute(struct xip_ppal_ctx *ctx,
-	struct fib_xid_table *xtbl, struct xia_fib_config *cfg)
+			  struct fib_xid_table *xtbl,
+			  struct xia_fib_config *cfg)
 {
 	int rc = fib_build_delroute(XRTABLE_LOCAL_INDEX, xtbl, cfg);
 	if (!rc) {
@@ -70,8 +72,8 @@ static int local_delroute(struct xip_ppal_ctx *ctx,
 }
 
 static int local_dump_hid(struct fib_xid *fxid, struct fib_xid_table *xtbl,
-	struct xip_ppal_ctx *ctx, struct sk_buff *skb,
-	struct netlink_callback *cb)
+			  struct xip_ppal_ctx *ctx, struct sk_buff *skb,
+			  struct netlink_callback *cb)
 {
 	struct nlmsghdr *nlh;
 	u32 portid = NETLINK_CB(cb->skb).portid;
@@ -80,7 +82,7 @@ static int local_dump_hid(struct fib_xid *fxid, struct fib_xid_table *xtbl,
 	struct xia_xid dst;
 
 	nlh = nlmsg_put(skb, portid, seq, RTM_NEWROUTE, sizeof(*rtm),
-		NLM_F_MULTI);
+			NLM_F_MULTI);
 	if (nlh == NULL)
 		return -EMSGSIZE;
 
@@ -123,7 +125,7 @@ static void local_free_hid(struct fib_xid_table *xtbl, struct fib_xid *fxid)
  */
 
 static int main_newroute(struct xip_ppal_ctx *ctx, struct fib_xid_table *xtbl,
-	struct xia_fib_config *cfg)
+			 struct xia_fib_config *cfg)
 {
 	if (!cfg->xfc_odev)
 		return -EINVAL;
@@ -137,7 +139,7 @@ static int main_newroute(struct xip_ppal_ctx *ctx, struct fib_xid_table *xtbl,
 }
 
 static int main_delroute(struct xip_ppal_ctx *ctx, struct fib_xid_table *xtbl,
-	struct xia_fib_config *cfg)
+			 struct xia_fib_config *cfg)
 {
 	if (!cfg->xfc_odev)
 		return -EINVAL;
@@ -151,8 +153,8 @@ static int main_delroute(struct xip_ppal_ctx *ctx, struct fib_xid_table *xtbl,
 }
 
 static int main_dump_hid(struct fib_xid *fxid, struct fib_xid_table *xtbl,
-	struct xip_ppal_ctx *ctx, struct sk_buff *skb,
-	struct netlink_callback *cb)
+			 struct xip_ppal_ctx *ctx, struct sk_buff *skb,
+			 struct netlink_callback *cb)
 {
 	struct nlmsghdr *nlh;
 	u32 portid = NETLINK_CB(cb->skb).portid;
@@ -164,7 +166,7 @@ static int main_dump_hid(struct fib_xid *fxid, struct fib_xid_table *xtbl,
 	struct hrdw_addr *pos_ha;
 
 	nlh = nlmsg_put(skb, portid, seq, RTM_NEWROUTE, sizeof(*rtm),
-		NLM_F_MULTI);
+			NLM_F_MULTI);
 	if (nlh == NULL)
 		return -EMSGSIZE;
 
@@ -267,7 +269,7 @@ static int __net_init hid_net_init(struct net *net)
 	}
 
 	rc = init_xid_table(&hid_ctx->ctx, net, &xia_main_lock_table,
-		hid_all_rt_eops);
+			    hid_all_rt_eops);
 	if (rc)
 		goto hid_ctx;
 
@@ -329,7 +331,7 @@ static int main_input_input(struct sk_buff *skb)
 		 * shouldn't it report more?
 		 */
 		LIMIT_NETDEBUG(KERN_WARNING pr_fmt("%s: hop limit reached\n"),
-			__func__);
+			       __func__);
 		goto drop;
 	}
 
@@ -403,7 +405,7 @@ static int main_input_output(struct sock *sk, struct sk_buff *skb)
 	 */
 	/* Fill the device header. */
 	rc = dev_hard_header(skb, skb->dev, ETH_P_XIP, ha->ha,
-		dev->dev_addr, skb->len);
+			     dev->dev_addr, skb->len);
 	if (rc < 0)
 		goto drop;
 
@@ -424,8 +426,8 @@ static int main_output_input(struct sk_buff *skb)
 #define main_output_output main_input_output
 
 static int hid_deliver(struct xip_route_proc *rproc, struct net *net,
-	const u8 *xid, struct xia_xid *next_xid, int anchor_index,
-	struct xip_dst *xdst)
+		       const u8 *xid, struct xia_xid *next_xid,
+		       int anchor_index, struct xip_dst *xdst)
 {
 	struct xip_ppal_ctx *ctx;
 	struct fib_xid *fxid;
@@ -451,7 +453,7 @@ static int hid_deliver(struct xip_route_proc *rproc, struct net *net,
 		struct fib_xid_hid_main *mhid = fxid_mhid(fxid);
 		struct hrdw_addr *ha =
 			list_first_or_null_rcu(&mhid->xhm_haddrs,
-				struct hrdw_addr, ha_list);
+					       struct hrdw_addr, ha_list);
 
 		if (unlikely(!ha)) {
 			/* @ha may be NULL because we don't have a lock over

--- a/net/xia/ppal_hid/main.c
+++ b/net/xia/ppal_hid/main.c
@@ -210,7 +210,7 @@ static int main_dump_hid(struct fib_xid *fxid, struct fib_xid_table *xtbl,
 		/* No attributes. */
 
 		/* length of rtnetlink header + attributes */
-		rtha->hha_len = nlmsg_get_pos(skb) - (void *) rtha;
+		rtha->hha_len = nlmsg_get_pos(skb) - (void *)rtha;
 	}
 	nla_nest_end(skb, ha_attr);
 

--- a/net/xia/ppal_hid/main.c
+++ b/net/xia/ppal_hid/main.c
@@ -7,9 +7,7 @@
 /* HID's virtal XID type. */
 int hid_vxt __read_mostly = -1;
 
-/*
- *	Local HIDs
- */
+/* Local HIDs */
 
 struct fib_xid_hid_local {
 	struct fib_xid	xhl_common;
@@ -124,9 +122,7 @@ static void local_free_hid(struct fib_xid_table *xtbl, struct fib_xid *fxid)
 	kfree(lhid);
 }
 
-/*
- *	Main HIDs
- */
+/* Main HIDs */
 
 static int main_newroute(struct xip_ppal_ctx *ctx, struct fib_xid_table *xtbl,
 			 struct xia_fib_config *cfg)
@@ -237,9 +233,7 @@ static const xia_ppal_all_rt_eops_t hid_all_rt_eops = {
 	},
 };
 
-/*
- *	Network namespace
- */
+/* Network namespace */
 
 static struct xip_hid_ctx *create_hid_ctx(struct net *net)
 {
@@ -308,9 +302,7 @@ static struct pernet_operations hid_net_ops __read_mostly = {
 	.exit = hid_net_exit,
 };
 
-/*
- *	HID Routing
- */
+/* HID Routing */
 
 static inline struct hrdw_addr *xdst_ha(struct xip_dst *xdst)
 {

--- a/net/xia/ppal_hid/main.c
+++ b/net/xia/ppal_hid/main.c
@@ -495,8 +495,7 @@ static struct xip_route_proc hid_rt_proc __read_mostly = {
 	.deliver = hid_deliver,
 };
 
-/*
- * xia_hid_init - this function is called when the module is loaded.
+/* xia_hid_init - this function is called when the module is loaded.
  * Returns zero if successfully loaded, nonzero otherwise.
  */
 static int __init xia_hid_init(void)
@@ -541,9 +540,7 @@ out:
 	return rc;
 }
 
-/*
- * xia_hid_exit - this function is called when the modlule is removed.
- */
+/* xia_hid_exit - this function is called when the modlule is removed. */
 static void __exit xia_hid_exit(void)
 {
 	ppal_del_map(XIDTYPE_HID);

--- a/net/xia/ppal_hid/nwp.c
+++ b/net/xia/ppal_hid/nwp.c
@@ -11,7 +11,7 @@
  */
 
 static struct hrdw_addr *new_ha(struct net_device *dev, const u8 *lladdr,
-	gfp_t flags)
+				gfp_t flags)
 {
 	struct hrdw_addr *ha = kzalloc(sizeof(*ha), flags);
 	if (!ha)
@@ -56,12 +56,12 @@ static inline void free_ha(struct hrdw_addr *ha)
 }
 
 static int ha_exists(struct fib_xid_hid_main *mhid, struct net_device *dev,
-	const u8 *lladdr)
+		     const u8 *lladdr)
 {
 	struct hrdw_addr *pos_ha;
 	list_for_each_entry(pos_ha, &mhid->xhm_haddrs, ha_list) {
 		if (unlikely(pos_ha->dev == dev &&
-			!memcmp(pos_ha->ha, lladdr, dev->addr_len)))
+			     !memcmp(pos_ha->ha, lladdr, dev->addr_len)))
 			return 1;	/* Yes! */
 	}
 	return 0;
@@ -143,7 +143,7 @@ static void del_ha(struct hrdw_addr *ha)
 }
 
 static int del_ha_from_mhid(struct fib_xid_hid_main *mhid, const u8 *str_ha,
-	struct net_device *dev)
+			    struct net_device *dev)
 {
 	struct hrdw_addr *pos_ha, *nxt;
 
@@ -208,7 +208,7 @@ static void free_neighs_by_dev(struct hid_dev *hdev)
 		 */
 		rcu_read_lock();
 		ha = list_first_or_null_rcu(&hdev->neighs, struct hrdw_addr,
-			hdev_list);
+					    hdev_list);
 		if (!ha) {
 			rcu_read_unlock();
 			break;
@@ -234,7 +234,7 @@ static void free_neighs_by_dev(struct hid_dev *hdev)
 }
 
 int insert_neigh(struct xip_hid_ctx *hid_ctx, const char *id,
-	struct net_device *dev, const u8 *lladdr, u32 nl_flags)
+		 struct net_device *dev, const u8 *lladdr, u32 nl_flags)
 {
 	struct hrdw_addr *ha;
 	struct fib_xid_table *xtbl;
@@ -272,7 +272,7 @@ int insert_neigh(struct xip_hid_ctx *hid_ctx, const char *id,
 
 		if (ha_exists(new_mhid, dev, lladdr)) {
 			if ((nl_flags & NLM_F_EXCL) ||
-				!(nl_flags & NLM_F_REPLACE)) {
+			    !(nl_flags & NLM_F_REPLACE)) {
 				rc = -EEXIST;
 				goto unlock_bucket;
 			}
@@ -343,7 +343,7 @@ ha:
 }
 
 int remove_neigh(struct fib_xid_table *xtbl, const char *id,
-	struct net_device *dev, const u8 *lladdr)
+		 struct net_device *dev, const u8 *lladdr)
 {
 	u32 bucket;
 	struct fib_xid *fxid;
@@ -453,7 +453,7 @@ static inline int announcement_hdr_len(struct net_device *dev)
 }
 
 static int __announce_on_dev(struct fib_xid_table *xtbl,
-	struct fib_xid *fxid, const void *arg)
+			     struct fib_xid *fxid, const void *arg)
 {
 	const struct announcement_state *state;
 	struct sk_buff *skb;
@@ -489,11 +489,11 @@ static int __announce_on_dev(struct fib_xid_table *xtbl,
 }
 
 static void send_nwp_frame(struct sk_buff *skb, const void *saddr,
-	const void *daddr)
+			   const void *daddr)
 {
 	/* Fill the device header. */
 	if (dev_hard_header(skb, skb->dev, ETH_P_NWP, daddr, saddr,
-		skb->len) < 0) {
+			    skb->len) < 0) {
 		kfree_skb(skb);
 		return;
 	}
@@ -517,7 +517,7 @@ static void announce_on_dev(struct fib_xid_table *xtbl, struct hid_dev *hdev)
 
 	if (mtu < min_annoucement) {
 		pr_err("XIA HID NWP: Can't send an announcement because dev %s has MTU (%u) smaller than the smallest annoucement frame (%i)\n",
-			dev->name, mtu, min_annoucement);
+		       dev->name, mtu, min_annoucement);
 		dump_stack();
 		return;
 	}
@@ -629,7 +629,8 @@ void hid_release_hid_state(struct xip_hid_ctx *hid_ctx)
  */
 
 static struct sk_buff *alloc_neigh_list_skb(struct net_device *dev,
-	unsigned int mtu, u8 **pphid_counter)
+					    unsigned int mtu,
+					    u8 **pphid_counter)
 {
 	int ll_hlen = LL_RESERVED_SPACE(dev);
 	int ll_tlen = dev->needed_tailroom;
@@ -641,7 +642,7 @@ static struct sk_buff *alloc_neigh_list_skb(struct net_device *dev,
 
 	if (mtu < min_list) {
 		pr_err("XIA HID NWP: Can't send a neighbor list because dev %s has MTU (%u) smaller than the smallest neighbor list frame (%i)\n",
-			dev->name, mtu, min_list);
+		       dev->name, mtu, min_list);
 		dump_stack();
 		return NULL;
 	}
@@ -858,7 +859,7 @@ static int process_neigh_list(struct sk_buff *skb)
 
 			/* Ignore errors. */
 			insert_neigh(hid_ctx, xid, dev, haddr_or_xid,
-				NLM_F_CREATE);
+				     NLM_F_CREATE);
 
 			haddr_or_xid = next_haddr_or_xid;
 			ha_count--;
@@ -874,7 +875,7 @@ out:
 
 /* This function is based on net/ipv4/arp.c:arp_rcv */
 static int nwp_rcv(struct sk_buff *skb, struct net_device *dev,
-	struct packet_type *pt, struct net_device *orig_dev)
+		   struct packet_type *pt, struct net_device *orig_dev)
 {
 	struct general_hdr *ghdr;
 
@@ -883,12 +884,12 @@ static int nwp_rcv(struct sk_buff *skb, struct net_device *dev,
 
 	ghdr = (struct general_hdr *)skb_network_header(skb);
 	if (ghdr->version != NWP_VERSION		||
-		ghdr->type >= NWP_TYPE_MAX		||
-		ghdr->hid_count == 0			||
-		ghdr->haddr_len != dev->addr_len	||
-		dev->flags & (IFF_NOARP | IFF_LOOPBACK)	||
-		skb->pkt_type == PACKET_OTHERHOST	||
-		skb->pkt_type == PACKET_LOOPBACK)
+	    ghdr->type >= NWP_TYPE_MAX			||
+	    ghdr->hid_count == 0			||
+	    ghdr->haddr_len != dev->addr_len		||
+	    dev->flags & (IFF_NOARP | IFF_LOOPBACK)	||
+	    skb->pkt_type == PACKET_OTHERHOST		||
+            skb->pkt_type == PACKET_LOOPBACK)
 		goto freeskb;
 
 	skb = skb_share_check(skb, GFP_ATOMIC);
@@ -928,7 +929,7 @@ void hid_dev_finish_destroy(struct hid_dev *hdev)
 #endif
 	if (!hdev->dead) {
 		pr_err("%s: freeing alive hid_dev %p=%s\n",
-			__func__, hdev, dev->name);
+		       __func__, hdev, dev->name);
 		dump_stack();
 	}
 
@@ -975,7 +976,7 @@ static void hdev_destroy(struct hid_dev *hdev)
 }
 
 static int hid_netdev_event(struct notifier_block *nb,
-	unsigned long event, void *ptr)
+			    unsigned long event, void *ptr)
 {
 	struct net_device *dev = netdev_notifier_info_to_dev(ptr);
 	struct hid_dev *hdev;

--- a/net/xia/ppal_hid/nwp.c
+++ b/net/xia/ppal_hid/nwp.c
@@ -18,7 +18,7 @@ static struct hrdw_addr *new_ha(struct net_device *dev, const u8 *lladdr,
 	if (!ha)
 		return NULL;
 	INIT_LIST_HEAD(&ha->ha_list);
-	INIT_LIST_HEAD(&ha->hdev_list);	
+	INIT_LIST_HEAD(&ha->hdev_list);
 	ha->dev = dev;
 	dev_hold(dev);
 	xdst_init_anchor(&ha->anchor);
@@ -902,7 +902,7 @@ static int nwp_rcv(struct sk_buff *skb, struct net_device *dev,
 	    ghdr->haddr_len != dev->addr_len		||
 	    dev->flags & (IFF_NOARP | IFF_LOOPBACK)	||
 	    skb->pkt_type == PACKET_OTHERHOST		||
-            skb->pkt_type == PACKET_LOOPBACK)
+	    skb->pkt_type == PACKET_LOOPBACK)
 		goto freeskb;
 
 	skb = skb_share_check(skb, GFP_ATOMIC);

--- a/net/xia/ppal_hid/nwp.c
+++ b/net/xia/ppal_hid/nwp.c
@@ -76,7 +76,8 @@ static int add_ha(struct fib_xid_hid_main *mhid, struct hrdw_addr *ha)
 	struct list_head *neighs_insert_here;
 
 	/* Inserting on mhid->xhm_haddrs. */
-	insert_here = same_dev = NULL;
+	same_dev = NULL;
+	insert_here = NULL;
 	list_for_each_entry(pos_ha, &mhid->xhm_haddrs, ha_list) {
 		int c1 = memcmp(pos_ha->ha, ha->ha, ha->dev->addr_len);
 		int c2 = pos_ha->dev == ha->dev;

--- a/net/xia/ppal_hid/nwp.c
+++ b/net/xia/ppal_hid/nwp.c
@@ -6,9 +6,7 @@
 #include <net/xia_dag.h>
 #include <net/xia_hid.h>
 
-/*
- *	Neighbor Table
- */
+/* Neighbor Table */
 
 static struct hrdw_addr *new_ha(struct net_device *dev, const u8 *lladdr,
 				gfp_t flags)
@@ -404,9 +402,7 @@ void main_free_hid(struct fib_xid_table *xtbl, struct fib_xid *fxid)
 	mhid_put(mhid);
 }
 
-/*
- *	Announce myself
- */
+/* Announce myself */
 
 struct announcement_state {
 	struct hid_dev	*hdev;
@@ -606,9 +602,7 @@ out:
 	mod_timer(&hid_ctx->announce_timer, jiffies + 5*HZ);
 }
 
-/*
- *	State associated to net
- */
+/* State associated to net */
 
 int hid_init_hid_state(struct xip_hid_ctx *hid_ctx)
 {
@@ -631,9 +625,7 @@ void hid_release_hid_state(struct xip_hid_ctx *hid_ctx)
 	del_timer_sync(&hid_ctx->announce_timer);
 }
 
-/*
- *	Receive NWP packets from the device layer
- */
+/* Receive NWP packets from the device layer */
 
 static struct sk_buff *alloc_neigh_list_skb(struct net_device *dev,
 					    unsigned int mtu,
@@ -930,9 +922,7 @@ static struct packet_type nwp_packet_type __read_mostly = {
 	.func = nwp_rcv,
 };
 
-/*
- *	Network Devices
- */
+/* Network Devices */
 
 void hid_dev_finish_destroy(struct hid_dev *hdev)
 {
@@ -1019,9 +1009,7 @@ static struct notifier_block hid_netdev_notifier __read_mostly = {
 	.notifier_call = hid_netdev_event,
 };
 
-/*
- *	Initialize NWP
- */
+/* Initialize NWP */
 
 int hid_nwp_init(void)
 {

--- a/net/xia/ppal_serval/main.c
+++ b/net/xia/ppal_serval/main.c
@@ -72,6 +72,7 @@ nla_put_failure:
 static void local_free_srvc(struct fib_xid_table *xtbl, struct fib_xid *fxid)
 {
 	struct serval_rt_id *rtid = fxid_rtid(fxid);
+
 	xdst_free_anchor(&rtid->anchor);
 	kfree(rtid);
 }
@@ -167,6 +168,7 @@ static int local_dump_flow(struct fib_xid *fxid, struct fib_xid_table *xtbl,
 		/* Add the other side of a socket. */
 		const struct serval_request_sock *srsk = flow_fxid_srsk(fxid);
 		struct xia_xid src;
+
 		src.xid_type = XIDTYPE_SRVCID;
 		memmove(src.xid_id, srsk->peer_srvcid.s_sid,
 			sizeof(src.xid_id));
@@ -197,6 +199,7 @@ static void local_free_flow(struct fib_xid_table *xtbl, struct fib_xid *fxid)
 	switch (fxid->fx_entry_type) {
 	case SOCK_TYPE: {
 		struct serval_rt_id *rtid = fxid_rtid(fxid);
+
 		xdst_free_anchor(&rtid->anchor);
 		kfree(rtid);
 		break;
@@ -204,6 +207,7 @@ static void local_free_flow(struct fib_xid_table *xtbl, struct fib_xid *fxid)
 
 	case REQUEST_SOCK_TYPE: {
 		struct serval_request_sock *srsk = flow_fxid_srsk(fxid);
+
 		xdst_free_anchor(&srsk->flow_anchor);
 		srsk_put(srsk);
 		break;
@@ -311,6 +315,7 @@ out:
 static void __net_exit serval_net_exit(struct net *net)
 {
 	struct xip_serval_ctx *serval_ctx, *serval_ctx2;
+
 	serval_ctx = flow_serval(xip_del_ppal_ctx(net, XIDTYPE_FLOWID));
 	serval_tcp_net_metrics_exit(serval_ctx);
 	serval_ctx2 = srvc_serval(xip_del_ppal_ctx(net, XIDTYPE_SRVCID));
@@ -482,6 +487,7 @@ static int flow_deliver(struct xip_route_proc *rproc, struct net *net,
 		switch (fxid->fx_entry_type) {
 		case SOCK_TYPE: {
 			struct serval_rt_id *rtid = fxid_rtid(fxid);
+
 			xdst->info = rtid_ssk(rtid);
 			if (xdst->input) {
 				xdst->dst.input = local_input_input;
@@ -497,6 +503,7 @@ static int flow_deliver(struct xip_route_proc *rproc, struct net *net,
 
 		case REQUEST_SOCK_TYPE: {
 			struct serval_request_sock *srsk = flow_fxid_srsk(fxid);
+
 			xdst->info = srsk->parent_ssk;
 			if (xdst->input) {
 				xdst->dst.input = serval_sal_rsk_rcv;
@@ -886,6 +893,7 @@ static int serval_connect(struct socket *sock, struct sockaddr *uaddr,
 
 	if ((1 << sk->sk_state) & (SALF_REQUEST | SALF_RESPOND)) {
 		long timeo = sock_sndtimeo(sk, flags & O_NONBLOCK);
+
 		if (!timeo) {
 			/* Error code is set above */
 			goto out;
@@ -997,6 +1005,7 @@ static int serval_accept(struct socket *sock, struct socket *newsock, int flags)
 
 	if (list_empty(&ssk->accept_queue)) {
 		long timeo = sock_rcvtimeo(sk, flags & O_NONBLOCK);
+
 		if (!timeo) {
 			/* If this is a non blocking socket don't sleep */
 			rc = -EAGAIN;
@@ -1023,6 +1032,7 @@ static unsigned int serval_poll(struct file *file, struct socket *sock,
 	sock_poll_wait(file, sk_sleep(sk), wait);
 	if (sk->sk_state == SAL_LISTEN) {
 		struct serval_sock *ssk = sk_ssk(sk);
+
 		return list_empty(&ssk->accept_queue) ? 0 :
 			(POLLIN | POLLRDNORM);
 	}

--- a/net/xia/ppal_serval/main.c
+++ b/net/xia/ppal_serval/main.c
@@ -17,9 +17,7 @@ struct netns_serval net_serval = {
 int srvc_vxt __read_mostly = -1;
 int flow_vxt __read_mostly = -1;
 
-/*
- *	Local ServiceID
- */
+/* Local ServiceID */
 
 static int local_dump_srvc(struct fib_xid *fxid, struct fib_xid_table *xtbl,
 			   struct xip_ppal_ctx *ctx, struct sk_buff *skb,
@@ -94,9 +92,7 @@ static const xia_ppal_all_rt_eops_t srvc_all_rt_eops = {
 	XIP_FIB_REDIRECT_MAIN,
 };
 
-/*
- *	Local FlowID
- */
+/* Local FlowID */
 
 static int local_dump_flow(struct fib_xid *fxid, struct fib_xid_table *xtbl,
 			   struct xip_ppal_ctx *ctx, struct sk_buff *skb,
@@ -245,9 +241,7 @@ static const xia_ppal_all_rt_eops_t flow_all_rt_eops = {
 	XIP_FIB_REDIRECT_MAIN,
 };
 
-/*
- *	Network namespace
- */
+/* Network namespace */
 
 static struct xip_serval_ctx *create_serval_ctx(void)
 {
@@ -328,9 +322,7 @@ static struct pernet_operations serval_net_ops __read_mostly = {
 	.exit = serval_net_exit,
 };
 
-/*
- *	Serval Routing
- */
+/* Serval Routing */
 
 /* XXX These local_* methods were copied from XDP, and probably should
  * be moved to XIA module to be shared between principals.
@@ -537,9 +529,7 @@ static struct xip_route_proc flow_rt_proc __read_mostly = {
 	.deliver = flow_deliver,
 };
 
-/*
- *	Socket API
- */
+/* Socket API */
 
 void serval_sock_init(struct serval_sock *ssk)
 {
@@ -1373,12 +1363,9 @@ static struct xia_socket_proc serval_sock_proc __read_mostly = {
 	.procs[SOCK_DGRAM]	= &serval_dgram,
 };
 
-/*
- *	Main
- */
+/* Main */
 
-/*
- *	Module parameters
+/* Module parameters
  *
  * Permissions (affect visibility in sysfs):
  * 0 = not visible in sysfs

--- a/net/xia/ppal_serval/main.c
+++ b/net/xia/ppal_serval/main.c
@@ -567,7 +567,9 @@ void serval_sock_init(struct serval_sock *ssk)
 	ssk->retransmits = 0;
 	ssk->backoff = 0;
 	ssk->srtt = 0;
-	ssk->mdev = ssk->mdev_max = ssk->rttvar = SAL_TIMEOUT_INIT;
+	ssk->rttvar = SAL_TIMEOUT_INIT;
+	ssk->mdev_max = SAL_TIMEOUT_INIT;
+	ssk->mdev = SAL_TIMEOUT_INIT;
 	ssk->rto = SAL_TIMEOUT_INIT;
 }
 

--- a/net/xia/ppal_serval/main.c
+++ b/net/xia/ppal_serval/main.c
@@ -22,8 +22,8 @@ int flow_vxt __read_mostly = -1;
  */
 
 static int local_dump_srvc(struct fib_xid *fxid, struct fib_xid_table *xtbl,
-	struct xip_ppal_ctx *ctx, struct sk_buff *skb,
-	struct netlink_callback *cb)
+			   struct xip_ppal_ctx *ctx, struct sk_buff *skb,
+			   struct netlink_callback *cb)
 {
 	const struct serval_sock *ssk;
 	struct nlmsghdr *nlh;
@@ -37,7 +37,7 @@ static int local_dump_srvc(struct fib_xid *fxid, struct fib_xid_table *xtbl,
 	}
 
 	nlh = nlmsg_put(skb, NETLINK_CB(cb->skb).portid, cb->nlh->nlmsg_seq,
-		RTM_NEWROUTE, sizeof(*rtm), NLM_F_MULTI);
+			RTM_NEWROUTE, sizeof(*rtm), NLM_F_MULTI);
 	if (nlh == NULL)
 		return -EMSGSIZE;
 
@@ -58,7 +58,7 @@ static int local_dump_srvc(struct fib_xid *fxid, struct fib_xid_table *xtbl,
 	dst.xid_type = xtbl_ppalty(xtbl);
 	memmove(dst.xid_id, fxid->fx_xid, XIA_XID_MAX);
 	if (unlikely(nla_put(skb, RTA_DST, sizeof(dst), &dst) ||
-		nla_put_u8(skb, RTA_PROTOINFO, ssk->xia_sk.sk.sk_state)))
+		     nla_put_u8(skb, RTA_PROTOINFO, ssk->xia_sk.sk.sk_state)))
 		goto nla_put_failure;
 
 	return nlmsg_end(skb, nlh);
@@ -98,8 +98,8 @@ static const xia_ppal_all_rt_eops_t srvc_all_rt_eops = {
  */
 
 static int local_dump_flow(struct fib_xid *fxid, struct fib_xid_table *xtbl,
-	struct xip_ppal_ctx *ctx, struct sk_buff *skb,
-	struct netlink_callback *cb)
+			   struct xip_ppal_ctx *ctx, struct sk_buff *skb,
+			   struct netlink_callback *cb)
 {
 	const struct serval_sock *ssk;
 	struct nlmsghdr *nlh;
@@ -119,7 +119,7 @@ static int local_dump_flow(struct fib_xid *fxid, struct fib_xid_table *xtbl,
 	}
 
 	nlh = nlmsg_put(skb, NETLINK_CB(cb->skb).portid, cb->nlh->nlmsg_seq,
-		RTM_NEWROUTE, sizeof(*rtm), NLM_F_MULTI);
+			RTM_NEWROUTE, sizeof(*rtm), NLM_F_MULTI);
 	if (nlh == NULL)
 		return -EMSGSIZE;
 
@@ -158,7 +158,7 @@ static int local_dump_flow(struct fib_xid *fxid, struct fib_xid_table *xtbl,
 				goto nla_put_failure;
 		}
 		if (unlikely(nla_put_u8(skb, RTA_PROTOINFO,
-			ssk->xia_sk.sk.sk_state)))
+					ssk->xia_sk.sk.sk_state)))
 			goto nla_put_failure;
 		break;
 	}
@@ -171,7 +171,7 @@ static int local_dump_flow(struct fib_xid *fxid, struct fib_xid_table *xtbl,
 		memmove(src.xid_id, srsk->peer_srvcid.s_sid,
 			sizeof(src.xid_id));
 		if (unlikely(nla_put(skb, RTA_SRC, sizeof(src), &src) ||
-			nla_put_u8(skb, RTA_PROTOINFO, SAL_RESPOND)))
+			     nla_put_u8(skb, RTA_PROTOINFO, SAL_RESPOND)))
 			goto nla_put_failure;
 		break;
 	}
@@ -276,11 +276,11 @@ static int __net_init serval_net_init(struct net *net)
 	}
 
 	rc = init_xid_table(&serval_ctx->srvc, net, &xia_main_lock_table,
-		srvc_all_rt_eops);
+			    srvc_all_rt_eops);
 	if (rc)
 		goto serval_ctx;
 	rc = init_xid_table(&serval_ctx->flow, net, &xia_main_lock_table,
-		flow_all_rt_eops);
+			    flow_all_rt_eops);
 	if (rc)
 		goto serval_ctx;
 
@@ -393,8 +393,8 @@ static int local_output_output(struct sock *sk, struct sk_buff *skb)
 }
 
 static int srvc_deliver(struct xip_route_proc *rproc, struct net *net,
-	const u8 *xid, struct xia_xid *next_xid, int anchor_index,
-	struct xip_dst *xdst)
+			const u8 *xid, struct xia_xid *next_xid,
+			int anchor_index, struct xip_dst *xdst)
 {
 	struct xip_ppal_ctx *ctx;
 	struct fib_xid *fxid;
@@ -451,8 +451,8 @@ static struct xip_route_proc srvc_rt_proc __read_mostly = {
 };
 
 static int flow_deliver(struct xip_route_proc *rproc, struct net *net,
-	const u8 *xid, struct xia_xid *next_xid, int anchor_index,
-	struct xip_dst *xdst)
+			const u8 *xid, struct xia_xid *next_xid,
+			int anchor_index, struct xip_dst *xdst)
 {
 	struct xip_ppal_ctx *ctx;
 	struct fib_xid *fxid;
@@ -491,7 +491,7 @@ static int flow_deliver(struct xip_route_proc *rproc, struct net *net,
 				xdst->dst.output = local_output_output;
 			}
 			xdst_attach_to_anchor(xdst, anchor_index,
-				&rtid->anchor);
+					      &rtid->anchor);
 			break;
 		}
 
@@ -506,7 +506,7 @@ static int flow_deliver(struct xip_route_proc *rproc, struct net *net,
 				xdst->dst.output = local_output_output;
 			}
 			xdst_attach_to_anchor(xdst, anchor_index,
-				&srsk->flow_anchor);
+					      &srsk->flow_anchor);
 			break;
 		}
 
@@ -547,9 +547,9 @@ void serval_sock_init(struct serval_sock *ssk)
 	INIT_LIST_HEAD(&ssk->accept_queue);
 	INIT_LIST_HEAD(&ssk->syn_queue);
 	setup_timer(&ssk->retransmit_timer, serval_sal_rexmit_timeout,
-		(unsigned long)sk);
+		    (unsigned long)sk);
 	setup_timer(&ssk->tw_timer, serval_sal_timewait_timeout,
-		(unsigned long)sk);
+		    (unsigned long)sk);
 
 	serval_sal_init_ctrl_queue(sk);
 
@@ -694,21 +694,21 @@ static inline struct serval_rt_id *rtid_alloc(gfp_t flags)
 
 /* Don't call this function, use rtid_init() or __rtid_init() instead. */
 static inline void __rtid_init_common(struct serval_rt_id *rtid,
-	struct serval_sock *ssk)
+				      struct serval_sock *ssk)
 {
 	xdst_init_anchor(&rtid->anchor);
 	RCU_INIT_POINTER(rtid->ssk, ssk);
 }
 
 static void __rtid_init(struct serval_rt_id *rtid, struct serval_sock *ssk,
-	int table_id, int entry_type)
+			int table_id, int entry_type)
 {
 	__init_fxid(&rtid->fxid, table_id, entry_type);
 	__rtid_init_common(rtid, ssk);
 }
 
 static void rtid_init(struct serval_rt_id *rtid, struct serval_sock *ssk,
-	const u8 *xid, int table_id, int entry_type)
+		      const u8 *xid, int table_id, int entry_type)
 {
 	init_fxid(&rtid->fxid, xid, table_id, entry_type);
 	__rtid_init_common(rtid, ssk);
@@ -724,7 +724,7 @@ static inline void __rtid_free_common(struct serval_rt_id *rtid)
  * has been called on @rtid.
  */
 static void rtid_free_norcu(struct fib_xid_table *xtbl,
-	struct serval_rt_id *rtid)
+			    struct serval_rt_id *rtid)
 {
 	__rtid_free_common(rtid);
 	free_fxid_norcu(xtbl, &rtid->fxid);
@@ -791,10 +791,10 @@ dnf:
 }
 
 static void serval_sock_unhash_s_f(struct sock *sk,
-	int unhash_srvc, int unhash_flow);
+				   int unhash_srvc, int unhash_flow);
 
 static int serval_connect(struct socket *sock, struct sockaddr *uaddr,
-	int addr_len, int flags)
+			  int addr_len, int flags)
 {
 	struct sock *sk = sock->sk;
 	struct serval_sock *ssk;
@@ -849,7 +849,7 @@ static int serval_connect(struct socket *sock, struct sockaddr *uaddr,
 		BUG_ON(ssk->flow_rtid);
 		serval_sock_set_state(sk, SAL_REQUEST);
 		xtbl = xip_find_my_ppal_ctx_vxt(sock_net(sk),
-			flow_vxt)->xpc_xtbl;
+						flow_vxt)->xpc_xtbl;
 		rc = fib_add_fxid(xtbl, &rtid->fxid);
 		if (rc) {
 			serval_sock_set_state(sk, SAL_CLOSED);
@@ -930,7 +930,7 @@ static int serval_wait_for_connect(struct sock *sk, long timeo)
 
 	for (;;) {
 		prepare_to_wait_exclusive(sk_sleep(sk), &wait,
-			TASK_INTERRUPTIBLE);
+					  TASK_INTERRUPTIBLE);
 		release_sock(sk);
 
 		if (list_empty(&ssk->accept_queue))
@@ -960,7 +960,7 @@ static int serval_wait_for_connect(struct sock *sk, long timeo)
 
 /* Caller must have the lock of @parent. */
 static struct sock *serval_accept_dequeue(struct sock *parent,
-	struct socket *newsock)
+					  struct socket *newsock)
 {
 	struct serval_sock *pssk = sk_ssk(parent);
 	struct serval_request_sock *srsk;
@@ -1015,7 +1015,7 @@ out:
 }
 
 static unsigned int serval_poll(struct file *file, struct socket *sock,
-	poll_table *wait)
+				poll_table *wait)
 {
 	struct sock *sk = sock->sk;
 	unsigned int mask;
@@ -1088,7 +1088,7 @@ void serval_sock_get_flowid(u8 *flowid)
 }
 
 int serval_swap_srsk_ssk_flowid(struct fib_xid *cur_fxid,
-	struct serval_sock *new_ssk)
+				struct serval_sock *new_ssk)
 {
 	struct xip_deferred_negdep_flush *dnf;
 	struct serval_rt_id *rtid;
@@ -1107,7 +1107,7 @@ int serval_swap_srsk_ssk_flowid(struct fib_xid *cur_fxid,
 		return -ENOMEM;
 	}
 	rtid_init(rtid, new_ssk, cur_fxid->fx_xid,
-		XRTABLE_LOCAL_INDEX, SOCK_TYPE);
+		  XRTABLE_LOCAL_INDEX, SOCK_TYPE);
 
 	net = sock_net(&new_ssk->xia_sk.sk);
 	xtbl = xip_find_my_ppal_ctx_vxt(net, flow_vxt)->xpc_xtbl;
@@ -1141,7 +1141,7 @@ int __serval_sock_hash_flowid(struct net *net, struct fib_xid *fxid)
 }
 
 static void serval_sock_unhash_s_f(struct sock *sk,
-	int unhash_srvc, int unhash_flow)
+				   int unhash_srvc, int unhash_flow)
 {
 	struct serval_sock *ssk = sk_ssk(sk);
 	struct net *net = sock_net(sk);
@@ -1270,7 +1270,7 @@ static int serval_shutdown(struct socket *sock, int how)
 }
 
 static int serval_sendmsg(struct kiocb *iocb, struct socket *sock,
-	struct msghdr *msg, size_t size)
+			  struct msghdr *msg, size_t size)
 {
 	struct sock *sk = sock->sk;
 
@@ -1282,14 +1282,16 @@ static int serval_sendmsg(struct kiocb *iocb, struct socket *sock,
 }
 
 extern unsigned int serval_tcp_poll(struct file *file, struct socket *sock,
-	poll_table *wait);
+				    poll_table *wait);
 
 #if defined(ENABLE_SPLICE)
 extern ssize_t serval_udp_splice_read(struct socket *sock, loff_t *ppos,
-	struct pipe_inode_info *pipe, size_t len, unsigned int flags);
+				      struct pipe_inode_info *pipe,
+				      size_t len, unsigned int flags);
 
 extern ssize_t serval_tcp_splice_read(struct socket *sock, loff_t *ppos,
-	struct pipe_inode_info *pipe, size_t len, unsigned int flags);
+				      struct pipe_inode_info *pipe,
+				      size_t len, unsigned int flags);
 #endif /* ENABLE_SPLICE */
 
 static const struct proto_ops serval_stream_ops = {

--- a/net/xia/ppal_serval/main.c
+++ b/net/xia/ppal_serval/main.c
@@ -444,7 +444,6 @@ static int srvc_deliver(struct xip_route_proc *rproc, struct net *net,
 		fib_mrd_redirect(fxid, next_xid);
 		rcu_read_unlock();
 		return XRP_ACT_REDIRECT;
-
 	}
 	rcu_read_unlock();
 	BUG();
@@ -528,7 +527,6 @@ static int flow_deliver(struct xip_route_proc *rproc, struct net *net,
 		fib_mrd_redirect(fxid, next_xid);
 		rcu_read_unlock();
 		return XRP_ACT_REDIRECT;
-
 	}
 	rcu_read_unlock();
 	BUG();
@@ -814,7 +812,6 @@ static int serval_connect(struct socket *sock, struct sockaddr *uaddr,
 	lock_sock(sk);
 
 	switch (sock->state) {
-
 	case SS_CONNECTED:
 		rc = -EISCONN;
 		goto out;

--- a/net/xia/ppal_serval/serval_sal.c
+++ b/net/xia/ppal_serval/serval_sal.c
@@ -426,7 +426,6 @@ static int serval_sal_write_xmit(struct sock *sk, unsigned int limit, gfp_t gfp)
 
 	while ((skb = serval_sal_send_head(sk)) &&
 	       (ssk->snd_seq.nxt - ssk->snd_seq.una) <= ssk->snd_seq.wnd) {
-
 		if (limit && num == limit)
 			break;
 

--- a/net/xia/ppal_serval/serval_sal.c
+++ b/net/xia/ppal_serval/serval_sal.c
@@ -272,8 +272,8 @@ static void serval_sal_rtt_estimator(struct sock *sk, const __u32 mrtt)
 		/* no previous measure. */
 		ssk->srtt = m << 3;	/* take the measured time to be rtt */
 		ssk->mdev = m << 1;	/* make sure rto = 3*rtt */
-		ssk->mdev_max = ssk->rttvar = max(ssk->mdev,
-						  serval_sal_rto_min(sk));
+		ssk->rttvar = max(ssk->mdev, serval_sal_rto_min(sk));
+		ssk->mdev_max = ssk->rttvar;
 		ssk->rtt_seq = ssk->snd_seq.nxt;
 	}
 }

--- a/net/xia/ppal_serval/serval_sal.c
+++ b/net/xia/ppal_serval/serval_sal.c
@@ -17,8 +17,7 @@
 
 int sysctl_sal_fin_timeout __read_mostly = SAL_FIN_TIMEOUT;
 
-/*
- * The next routines deal with comparing 32 bit unsigned ints
+/* The next routines deal with comparing 32 bit unsigned ints
  * and worry about wraparound (automatic with unsigned arithmetic).
  * Taken from linux/net/tcp.h.
  */
@@ -203,8 +202,8 @@ static inline u32 serval_sal_rto_min(struct sock *sk)
 }
 
 /* The RTO estimation for the SAL is taken directly from the Linux
-   kernel TCP code. */
-/* Called to compute a smoothed rtt estimate. The data fed to this
+ * kernel TCP code.
+ * Called to compute a smoothed rtt estimate. The data fed to this
  * routine either comes from timestamps, or from segments that were
  * known _not_ to have been retransmitted [see Karn/Partridge
  * Proceedings SIGCOMM 87]. The algorithm is from the SIGCOMM 88
@@ -655,7 +654,8 @@ static int serval_sal_send_rsyn(struct sock *sk, u32 verno)
 	case SAL_RSYN_SENT:
 	case SAL_RSYN_SENT_RECV:
 		/* Here we just move to the same state again, so
-		   nothing to do. */
+		 * nothing to do.
+		 */
 		break;
 	}
 
@@ -1677,13 +1677,15 @@ static int serval_sal_connected_state_process(struct sock *sk,
 	}
 
 	/* Should pass FINs to transport and ultimately the user, as
-	 * it needs to pick it off its receive queue to notice EOF. */
+	 * it needs to pick it off its receive queue to notice EOF.
+	 */
 	if (packet_has_transport_hdr(skb, ctx->hdr) || (ctx->flags & SVH_FIN)) {
 		ssk->last_rcv_tstamp = sal_time_stamp;
 		err = ssk->af_ops->receive(sk, skb);
 	} else {
 		/* No transport header, so we just drop the packet
-		 * since there is nothing more to do with it. */
+		 * since there is nothing more to do with it.
+		 */
 		err = 0;
 		should_drop = 1;
 	}
@@ -2246,22 +2248,21 @@ static int serval_sal_do_xmit(struct sk_buff *skb)
 		sk_dst_reset(sk);
 	}
 
-	/*
-	  XXX we kind of hard code the outgoing device here based
-	  on what has been bound to the socket in the connection
-	  setup phase. Instead, the device should be resolved based
-	  on, e.g., dst IP (if it exists at this point).
-
-	  However, we currently do not implement an IP routing table
-	  for userlevel, which would otherwise be used for this
-	  resolution. Kernel space should work, because it routes
-	  packet according to the kernel's routing table, thus
-	  figuring out the device along the way.
-
-	  Packets that are sent using an advisory IP may fail in
-	  queue_xmit for userlevel unless the socket has had its
-	  interface set by a previous send event.
-	*/
+	/* XXX we kind of hard code the outgoing device here based
+	 * on what has been bound to the socket in the connection
+	 * setup phase. Instead, the device should be resolved based
+	 * on, e.g., dst IP (if it exists at this point).
+	 *
+	 * However, we currently do not implement an IP routing table
+	 * for userlevel, which would otherwise be used for this
+	 * resolution. Kernel space should work, because it routes
+	 * packet according to the kernel's routing table, thus
+	 * figuring out the device along the way.
+	 *
+	 * Packets that are sent using an advisory IP may fail in
+	 * queue_xmit for userlevel unless the socket has had its
+	 * interface set by a previous send event.
+	 */
 	rc = xip_local_out(skb);
 
 	if (skb_flags & SVH_RSYN) {

--- a/net/xia/ppal_serval/serval_sock.c
+++ b/net/xia/ppal_serval/serval_sock.c
@@ -1,9 +1,6 @@
 THIS FILE AND ITS HEADER FILES ARE ONLY KEPT HERE TO HELP
 IMPLEMETING SOCKET MIGRATION.
 
-
-
-
 /* Serval socket implementation. Contains all the Serval-specific state.
  *
  * Authors: Erik Nordström <enordstr@cs.princeton.edu>

--- a/net/xia/ppal_serval/serval_sock.c
+++ b/net/xia/ppal_serval/serval_sock.c
@@ -258,6 +258,7 @@ static unsigned long get_socket_inode(struct socket *socket)
 	if (socket) {
 		struct address_space *faddr;
 		struct inode *inode;
+
 		if (!socket->file)
 			goto out;
 
@@ -282,10 +283,12 @@ struct flow_info *serval_sock_stats_flow(struct flow_id *flow)
 		int info_size = sizeof(struct flow_id) + sizeof(uint8_t)
 				sizeof(unsigned long) + sizeof(uint16_t);
 		struct socket *socket = sk->sk_socket;
+
 		if (sk->sk_protocol == IPPROTO_TCP) {
 			struct serval_tcp_sock *tsk =
 				(struct serval_tcp_sock *) sk;
 			struct stats_proto_tcp *st = NULL;
+
 			info_size += sizeof(struct stats_proto_tcp);
 			ret = kmalloc(info_size, GFP_KERNEL);
 			memset(ret, 0, info_size);
@@ -341,6 +344,7 @@ static struct sock *serval_sock_lookup(struct serval_table *table,
 
 	hlist_for_each_entry(sk, &slot->head, sk_node) {
 		struct serval_sock *ssk = sk_ssk(sk);
+
 		if (memcmp(key, ssk->hash_key, keylen) == 0) {
 			sock_hold(sk);
 			goto out;

--- a/net/xia/ppal_serval/serval_sock.c
+++ b/net/xia/ppal_serval/serval_sock.c
@@ -286,7 +286,7 @@ struct flow_info *serval_sock_stats_flow(struct flow_id *flow)
 
 		if (sk->sk_protocol == IPPROTO_TCP) {
 			struct serval_tcp_sock *tsk =
-				(struct serval_tcp_sock *) sk;
+				(struct serval_tcp_sock *)sk;
 			struct stats_proto_tcp *st = NULL;
 
 			info_size += sizeof(struct stats_proto_tcp);

--- a/net/xia/ppal_serval/serval_sock.c
+++ b/net/xia/ppal_serval/serval_sock.c
@@ -4,8 +4,7 @@ IMPLEMETING SOCKET MIGRATION.
 
 
 
-/*
- * Serval socket implementation. Contains all the Serval-specific state.
+/* Serval socket implementation. Contains all the Serval-specific state.
  *
  * Authors: Erik Nordström <enordstr@cs.princeton.edu>
  *
@@ -127,29 +126,32 @@ void serval_sock_migrate_iface(int old_dev, int new_dev)
 					/* We were told which
 					 * interface to migrate, but
 					 * we need to check that this
-					 * sock matches. */
+					 * sock matches.
+					 */
 					should_migrate = sk->sk_bound_dev_if
 						== old_dev;
 				}
 			} else if (old_dev <= 0) {
 				/* A new interface came up, migrate all flows
 				 * with a DOWN interface to this new
-				 * interface. */
+				 * interface.
+				 */
 				struct net_device *i = dev_get_by_index(
 					sock_net(sk), sk->sk_bound_dev_if);
 
 				if (i) {
 					/* If this interface is down, then
-					 * migrate its flows. */
+					 * migrate its flows.
+					 */
 					if (!(i->flags & IFF_UP))
 						should_migrate = 1;
 					dev_put(i);
 				}
 			} else if (new_dev <= 0 &&
 				old_dev == sk->sk_bound_dev_if) {
-				/* An interface went down, and we
-				 * need to figure out a new target
-				 * dev. */
+				/* An interface went down, and we need
+				 * to figure out a new target dev.
+				 */
 				struct rtable *rt;
 
 				rt = serval_ip_route_output(sock_net(sk),

--- a/net/xia/ppal_serval/serval_sock.c
+++ b/net/xia/ppal_serval/serval_sock.c
@@ -55,7 +55,8 @@ static const char * const sock_sal_state_str[] = {
 static int serval_table_init(struct serval_table *table,
 	unsigned int (*hashfn)(struct serval_table *tbl, struct sock *sk),
 	struct serval_hslot *(*hashslot)(struct serval_table *tbl,
-		struct net *net, void *key, size_t keylen))
+					 struct net *net, void *key,
+					 size_t keylen))
 {
 	unsigned int i;
 

--- a/net/xia/ppal_serval/serval_tcp.c
+++ b/net/xia/ppal_serval/serval_tcp.c
@@ -661,9 +661,8 @@ unsigned int serval_tcp_poll(struct file *file,
 }
 
 #if defined(ENABLE_SPLICE)
-/*
- *	TCP splice context
- */
+
+/* TCP splice context */
 
 struct tcp_splice_state {
 	struct pipe_inode_info *pipe;
@@ -1684,9 +1683,7 @@ static void serval_tcp_v4_send_check(struct sock *sk, struct sk_buff *skb)
 	__serval_tcp_v4_send_check(skb);
 }
 
-/*
- *	Socket option code for TCP
- */
+/* Socket option code for TCP */
 
 static int serval_do_tcp_setsockopt(struct sock *sk, int level,
 				    int optname, char __user *optval,

--- a/net/xia/ppal_serval/serval_tcp.c
+++ b/net/xia/ppal_serval/serval_tcp.c
@@ -1544,7 +1544,6 @@ found_ok_skb:
 						tp->ucopy.pinned_list);
 
 				if (tp->ucopy.dma_cookie < 0) {
-
 					printk(KERN_ALERT "dma_cookie < 0\n");
 
 					/* Exception. Bailout! */

--- a/net/xia/ppal_serval/serval_tcp.c
+++ b/net/xia/ppal_serval/serval_tcp.c
@@ -92,6 +92,7 @@ static int serval_tcp_disconnect(struct sock *sk, int flags)
 __u32 serval_tcp_random_sequence_number(void)
 {
 	__u32 isn;
+
 	get_random_bytes(&isn, sizeof(isn));
 	return isn;
 }
@@ -273,6 +274,7 @@ static int serval_tcp_rcv(struct sock *sk, struct sk_buff *skb)
 	if (!sock_owned_by_user(sk)) {
 #ifdef CONFIG_NET_DMA
 		struct serval_tcp_sock *tp = serval_tcp_sk(sk);
+
 		if (!tp->ucopy.dma_chan && tp->ucopy.pinned_list)
 			tp->ucopy.dma_chan = dma_find_channel(DMA_MEMCPY);
 		if (tp->ucopy.dma_chan)
@@ -538,6 +540,7 @@ static void serval_tcp_service_net_dma(struct sock *sk, bool wait)
 			break;
 		} else {
 			struct sk_buff *skb;
+
 			while ((skb = skb_peek(&sk->sk_async_wait_queue)) &&
 			       (dma_async_is_complete(skb->dma_cookie, done,
 						      used) == DMA_SUCCESS)) {
@@ -716,6 +719,7 @@ int serval_tcp_read_sock(struct sock *sk, read_descriptor_t *desc,
 			/* Stop reading if we hit a patch of urgent data */
 			if (tp->urg_data) {
 				u32 urg_offset = tp->urg_seq - seq;
+
 				if (urg_offset < len)
 					len = urg_offset;
 				if (!len)
@@ -1507,6 +1511,7 @@ found_ok_skb:
 		/* Do we have urgent data here? */
 		if (tp->urg_data) {
 			u32 urg_offset = tp->urg_seq - *seq;
+
 			if (urg_offset < used) {
 				if (!urg_offset) {
 					if (!sock_flag(sk, SOCK_URGINLINE)) {
@@ -1665,6 +1670,7 @@ void __serval_tcp_v4_send_check(struct sk_buff *skb)
 {
 	struct tcphdr *th = tcp_hdr(skb);
 	unsigned long len = skb_tail_pointer(skb) - skb_transport_header(skb);
+
 	skb->ip_summed = CHECKSUM_NONE;
 	th->check = serval_tcp_v4_check(len, csum_partial(th, len, 0));
 }
@@ -1885,6 +1891,7 @@ static int serval_do_tcp_setsockopt(struct sock *sk, int level,
 			    !((1 << sk->sk_state) &
 			      (TCPF_CLOSE | TCPF_LISTEN))) {
 				u32 elapsed = serval_keepalive_time_elapsed(tp);
+
 				if (tp->keepalive_time > elapsed)
 					elapsed = tp->keepalive_time - elapsed;
 				else

--- a/net/xia/ppal_serval/serval_tcp.c
+++ b/net/xia/ppal_serval/serval_tcp.c
@@ -480,9 +480,9 @@ static inline int select_size(struct sock *sk, int sg)
 	int tmp = tp->mss_cache;
 
 	if (sg) {
-		if (0 /* sk_can_gso(sk) */)
+		if (0 /* sk_can_gso(sk) */) {
 			tmp = 0;
-		else {
+		} else {
 			int pgbreak = SKB_MAX_HEAD(MAX_SERVAL_TCP_HEADER);
 
 			if (tmp >= pgbreak &&
@@ -644,9 +644,9 @@ unsigned int serval_tcp_poll(struct file *file,
 					sk_stream_min_wspace(sk))
 					mask |= POLLOUT | POLLWRNORM;
 			}
-		} else
+		} else {
 			mask |= POLLOUT | POLLWRNORM;
-
+		}
 		if (tp->urg_data & TCP_URG_VALID)
 			mask |= POLLPRI;
 	}
@@ -836,9 +836,9 @@ ssize_t serval_tcp_splice_read(struct socket *sock, loff_t *ppos,
 	while (tss.len) {
 		if (!serval_tcp_sk(sk)->fin_found)
 			ret = __serval_tcp_splice_read(sk, &tss);
-		if (ret < 0)
+		if (ret < 0) {
 			break;
-		else if (!ret) {
+		} else if (!ret) {
 			if (spliced)
 				break;
 			if (sock_flag(sk, SOCK_DONE))
@@ -1066,8 +1066,9 @@ new_segment:
 				serval_tcp_mark_push(tp, skb);
 				__serval_tcp_push_pending_frames(sk, mss_now,
 					TCP_NAGLE_PUSH);
-			} else if (skb == tcp_send_head(sk))
+			} else if (skb == tcp_send_head(sk)) {
 				serval_tcp_push_one(sk, mss_now);
+			}
 			continue;
 
 wait_for_sndbuf:
@@ -1139,9 +1140,9 @@ static int serval_tcp_recv_urg(struct sock *sk, struct msghdr *msg,
 			if (!(flags & MSG_TRUNC))
 				err = memcpy_toiovec(msg->msg_iov, &c, 1);
 			len = 1;
-		} else
+		} else {
 			msg->msg_flags |= MSG_TRUNC;
-
+		}
 		return err ? -EFAULT : len;
 	}
 
@@ -1522,8 +1523,9 @@ found_ok_skb:
 						if (!used)
 							goto skip_copy;
 					}
-				} else
+				} else {
 					used = urg_offset;
+				}
 			}
 		}
 
@@ -1883,9 +1885,9 @@ static int serval_do_tcp_setsockopt(struct sock *sk, int level,
 		break;
 
 	case TCP_KEEPIDLE:
-		if (val < 1 || val > MAX_TCP_KEEPIDLE)
+		if (val < 1 || val > MAX_TCP_KEEPIDLE) {
 			err = -EINVAL;
-		else {
+		} else {
 			tp->keepalive_time = val * HZ;
 			if (sock_flag(sk, SOCK_KEEPOPEN) &&
 			    !((1 << sk->sk_state) &
@@ -2154,12 +2156,12 @@ int serval_tcp_ioctl(struct sock *sk, int cmd, unsigned long arg)
 			return -EINVAL;
 
 		lock_sock(sk);
-		if ((1 << sk->sk_state) & (TCPF_SYN_SENT | TCPF_SYN_RECV))
+		if ((1 << sk->sk_state) & (TCPF_SYN_SENT | TCPF_SYN_RECV)) {
 			answ = 0;
-		else if (sock_flag(sk, SOCK_URGINLINE) ||
-			 !tp->urg_data ||
-			 before(tp->urg_seq, tp->copied_seq) ||
-			 !before(tp->urg_seq, tp->rcv_nxt)) {
+		} else if (sock_flag(sk, SOCK_URGINLINE) ||
+			   !tp->urg_data ||
+			   before(tp->urg_seq, tp->copied_seq) ||
+			   !before(tp->urg_seq, tp->rcv_nxt)) {
 			struct sk_buff *skb;
 
 			answ = tp->rcv_nxt - tp->copied_seq;
@@ -2168,8 +2170,9 @@ int serval_tcp_ioctl(struct sock *sk, int cmd, unsigned long arg)
 			skb = skb_peek_tail(&sk->sk_receive_queue);
 			if (answ && skb)
 				answ -= tcp_hdr(skb)->fin;
-		} else
+		} else {
 			answ = tp->urg_seq - tp->copied_seq;
+		}
 		release_sock(sk);
 		break;
 	case SIOCATMARK:

--- a/net/xia/ppal_serval/serval_tcp.c
+++ b/net/xia/ppal_serval/serval_tcp.c
@@ -102,7 +102,8 @@ static inline __u32 serval_tcp_init_sequence(struct sk_buff *skb)
 }
 
 static void serval_tcp_openreq_init(struct serval_tcp_request_sock *trsk,
-	struct serval_tcp_options_received *rx_opt, struct sk_buff *skb)
+				    struct serval_tcp_options_received *rx_opt,
+				    struct sk_buff *skb)
 {
 	struct request_sock *req = &trsk->rsk.req;
 
@@ -121,7 +122,8 @@ static void serval_tcp_openreq_init(struct serval_tcp_request_sock *trsk,
 }
 
 static int serval_tcp_connection_request(struct sock *sk,
-	struct request_sock *req, struct sk_buff *skb)
+					 struct request_sock *req,
+					 struct sk_buff *skb)
 {
 	struct serval_tcp_sock *tp = serval_tcp_sk(sk);
 	struct serval_tcp_request_sock *trsk = serval_tcp_rsk(req);
@@ -146,7 +148,8 @@ static int serval_tcp_connection_request(struct sock *sk,
 }
 
 static int serval_tcp_syn_recv_sock(struct sock *sk, struct sk_buff *skb,
-	struct request_sock *rsk, struct sock *child, struct dst_entry *dst);
+				    struct request_sock *rsk,
+				    struct sock *child, struct dst_entry *dst);
 
 int serval_tcp_do_rcv(struct sock *sk, struct sk_buff *skb)
 {
@@ -396,7 +399,7 @@ static int serval_tcp_send_mss(struct sock *sk, int *size_goal, int flags)
 }
 
 static inline void serval_tcp_mark_push(struct serval_tcp_sock *tp,
-				 struct sk_buff *skb)
+					struct sk_buff *skb)
 {
 	TCP_SKB_CB(skb)->tcp_flags |= TCPH_PSH;
 	tp->pushed_seq = tp->write_seq;
@@ -503,7 +506,7 @@ static inline void serval_tcp_push(struct sock *sk, int flags, int mss_now,
 
 		if (!(flags & MSG_MORE) || forced_push(tp))
 			serval_tcp_mark_push(tp,
-				serval_tcp_write_queue_tail(sk));
+					     serval_tcp_write_queue_tail(sk));
 
 		serval_tcp_mark_urg(tp, flags);
 
@@ -528,8 +531,8 @@ static void serval_tcp_service_net_dma(struct sock *sk, bool wait)
 
 	do {
 		if (dma_async_is_tx_complete(tp->ucopy.dma_chan,
-					      last_issued, &done,
-					      &used) == DMA_SUCCESS) {
+					     last_issued, &done,
+					     &used) == DMA_SUCCESS) {
 			/* Safe to free early-copied skbs now */
 			__skb_queue_purge(&sk->sk_async_wait_queue);
 			break;
@@ -891,7 +894,7 @@ ssize_t serval_tcp_splice_read(struct socket *sock, loff_t *ppos,
 #endif /* ENABLE_SPLICE */
 
 static int serval_tcp_sendmsg(struct kiocb *iocb, struct sock *sk,
-	struct msghdr *msg, size_t size)
+			      struct msghdr *msg, size_t size)
 {
 	struct iovec *iov;
 	struct serval_tcp_sock *tp = serval_tcp_sk(sk);
@@ -1020,7 +1023,7 @@ new_segment:
 				}
 
 				copy = min_t(int, copy,
-					pfrag->size - pfrag->offset);
+					     pfrag->size - pfrag->offset);
 
 				if (!sk_wmem_schedule(sk, copy))
 					goto wait_for_memory;
@@ -1073,7 +1076,7 @@ wait_for_sndbuf:
 wait_for_memory:
 			if (copied)
 				serval_tcp_push(sk, flags & ~MSG_MORE, mss_now,
-					TCP_NAGLE_PUSH);
+						TCP_NAGLE_PUSH);
 
 			if ((err = sk_stream_wait_memory(sk, &timeo)) != 0)
 				goto do_error;
@@ -2248,7 +2251,9 @@ static struct serval_sock_af_ops serval_tcp_af_ops = {
 
 /* Adapted from tcp_minisocks.c. */
 static void serval_tcp_create_openreq_child(struct sock *sk,
-	struct request_sock *req, struct sock *newsk, struct sk_buff *skb)
+					    struct request_sock *req,
+					    struct sock *newsk,
+					    struct sk_buff *skb)
 {
 	struct serval_tcp_request_sock *treq = serval_tcp_rsk(req);
 	struct serval_sock *newssk = sk_ssk(newsk);
@@ -2364,7 +2369,8 @@ static void serval_tcp_create_openreq_child(struct sock *sk,
  * three-way handshake on the server side.
  */
 static int serval_tcp_syn_recv_sock(struct sock *sk, struct sk_buff *skb,
-	struct request_sock *req, struct sock *newsk, struct dst_entry *dst)
+				    struct request_sock *req,
+				    struct sock *newsk, struct dst_entry *dst)
 {
 	struct serval_tcp_sock *newtp = serval_tcp_sk(newsk);
 

--- a/net/xia/ppal_serval/serval_tcp_cong.c
+++ b/net/xia/ppal_serval/serval_tcp_cong.c
@@ -46,8 +46,7 @@ int serval_tcp_is_cwnd_limited(const struct sock *sk, u32 in_flight)
 	return left <= serval_tcp_max_burst(tp);
 }
 
-/*
- * Slow start is used when congestion window is less than slow start
+/* Slow start is used when congestion window is less than slow start
  * threshold. This version implements the basic RFC2581 version
  * and optionally supports:
  *	RFC3742 Limited Slow Start	  - growth limited to max_ssthresh
@@ -104,10 +103,10 @@ void serval_tcp_cong_avoid_ai(struct serval_tcp_sock *tp, u32 w)
 }
 
 /*
- * TCP Reno congestion control
+ *	TCP Reno congestion control
+ *
  * This is special case used for fallback as well.
- */
-/* This is Jacobson's slow start and congestion avoidance.
+ * This is Jacobson's slow start and congestion avoidance.
  * SIGCOMM '88, p. 328.
  */
 void serval_tcp_reno_cong_avoid(struct sock *sk, u32 ack, u32 in_flight)
@@ -136,7 +135,7 @@ void serval_tcp_reno_cong_avoid(struct sock *sk, u32 ack, u32 in_flight)
 	}
 }
 
-/* Slow start threshold is half the congestion window (min 2) */
+/* Slow start threshold is half the congestion window (min 2). */
 u32 serval_tcp_reno_ssthresh(struct sock *sk)
 {
 	const struct serval_tcp_sock *tp = serval_tcp_sk(sk);

--- a/net/xia/ppal_serval/serval_tcp_cong.c
+++ b/net/xia/ppal_serval/serval_tcp_cong.c
@@ -102,8 +102,7 @@ void serval_tcp_cong_avoid_ai(struct serval_tcp_sock *tp, u32 w)
 	}
 }
 
-/*
- *	TCP Reno congestion control
+/* TCP Reno congestion control
  *
  * This is special case used for fallback as well.
  * This is Jacobson's slow start and congestion avoidance.

--- a/net/xia/ppal_serval/serval_tcp_cong.c
+++ b/net/xia/ppal_serval/serval_tcp_cong.c
@@ -68,7 +68,7 @@ void serval_tcp_slow_start(struct serval_tcp_sock *tp)
 		return;
 
 	if (sysctl_serval_tcp_max_ssthresh > 0 &&
-		tp->snd_cwnd > sysctl_serval_tcp_max_ssthresh) {
+	    tp->snd_cwnd > sysctl_serval_tcp_max_ssthresh) {
 		/* Limited slow start. */
 		cnt = sysctl_serval_tcp_max_ssthresh >> 1;
 	} else {

--- a/net/xia/ppal_serval/serval_tcp_input.c
+++ b/net/xia/ppal_serval/serval_tcp_input.c
@@ -2265,8 +2265,7 @@ void serval_tcp_parse_options(struct sk_buff *skb,
 				break;
 #ifdef CONFIG_TCP_MD5SIG
 			case TCPOPT_MD5SIG:
-				/*
-				 * The MD5 Hash has already been
+				/* The MD5 Hash has already been
 				 * checked (see tcp_v{4,6}_do_rcv()).
 				 */
 				break;

--- a/net/xia/ppal_serval/serval_tcp_input.c
+++ b/net/xia/ppal_serval/serval_tcp_input.c
@@ -382,13 +382,14 @@ new_measure:
 }
 
 static inline void serval_tcp_rcv_rtt_measure_ts(struct sock *sk,
-	struct sk_buff *skb)
+						 struct sk_buff *skb)
 {
 	struct serval_tcp_sock *tp = serval_tcp_sk(sk);
 	if (tp->rx_opt.rcv_tsecr && (TCP_SKB_CB(skb)->end_seq -
 		TCP_SKB_CB(skb)->seq >= tp->tp_ack.rcv_mss))
 		serval_tcp_rcv_rtt_update(tp,
-			tcp_time_stamp - tp->rx_opt.rcv_tsecr, 0);
+					  tcp_time_stamp - tp->rx_opt.rcv_tsecr,
+					  0);
 }
 
 /*
@@ -1013,7 +1014,8 @@ static int serval_tcp_try_undo_partial(struct sock *sk, int acked)
 			tp->retrans_stamp = 0;
 
 		serval_tcp_update_reordering(sk,
-			serval_tcp_fackets_out(tp) + acked, 1);
+					     serval_tcp_fackets_out(tp) + acked,
+					     1);
 
 		/* DBGUNDO(sk, "Hoe"); */
 		serval_tcp_undo_cwr(sk, 0);
@@ -1162,7 +1164,7 @@ static int serval_tcp_check_sack_reneging(struct sock *sk, int flag)
 
 /* This must be called before lost_out is incremented */
 static void serval_tcp_verify_retransmit_hint(struct serval_tcp_sock *tp,
-	struct sk_buff *skb)
+					      struct sk_buff *skb)
 {
 	if ((tp->retransmit_skb_hint == NULL) ||
 	    before(TCP_SKB_CB(skb)->seq,
@@ -1317,13 +1319,14 @@ static void serval_tcp_mark_head_lost(struct sock *sk,
 
 		if (cnt > packets) {
 			if ((serval_tcp_is_sack(tp) &&
-				!serval_tcp_is_fack(tp)) ||
-				(oldcnt >= packets))
+			     !serval_tcp_is_fack(tp)) ||
+			     (oldcnt >= packets))
 				break;
 
 			mss = skb_shinfo(skb)->gso_size;
 			err = serval_tcp_fragment(sk, skb,
-				(packets - oldcnt) * mss, mss);
+						  (packets - oldcnt) * mss,
+						  mss);
 			if (err < 0)
 				break;
 			cnt = packets;
@@ -1410,9 +1413,9 @@ static int serval_tcp_time_to_recover(struct sock *sk)
 	 * Use only if there are no unsent data.
 	 */
 	if ((tp->thin_dupack || sysctl_serval_tcp_thin_dupack) &&
-		serval_tcp_stream_is_thin(tp) &&
-		serval_tcp_dupack_heuristics(tp) > 1 &&
-		serval_tcp_is_sack(tp) && !serval_tcp_send_head(sk))
+	    serval_tcp_stream_is_thin(tp) &&
+	    serval_tcp_dupack_heuristics(tp) > 1 &&
+	    serval_tcp_is_sack(tp) && !serval_tcp_send_head(sk))
 		return 1;
 
 	return 0;
@@ -1518,7 +1521,7 @@ static void serval_tcp_fastretrans_alert(struct sock *sk,
 	    tp->ca_state != TCP_CA_Open &&
 	    tp->fackets_out > tp->reordering) {
 		serval_tcp_mark_head_lost(sk,
-			tp->fackets_out - tp->reordering, 0);
+					  tp->fackets_out - tp->reordering, 0);
 		/* NET_INC_STATS_BH(sock_net(sk), LINUX_MIB_TCPLOSS); */
 	}
 
@@ -1807,7 +1810,7 @@ static inline int serval_tcp_may_update_window(const struct serval_tcp_sock *tp,
  * and in FreeBSD. NetBSD's one is even worse.) is wrong.
  */
 static int serval_tcp_ack_update_window(struct sock *sk, struct sk_buff *skb,
-					 u32 ack, u32 ack_seq)
+					u32 ack, u32 ack_seq)
 {
 	struct serval_tcp_sock *tp = serval_tcp_sk(sk);
 	int flag = 0;
@@ -1997,7 +2000,7 @@ static int serval_tcp_clean_rtx_queue(struct sock *sk,
 
 			/* Is the ACK triggering packet unambiguous? */
 			if (!(flag & FLAG_RETRANS_DATA_ACKED) &&
-				ca_seq_rtt > 0)
+			    ca_seq_rtt > 0)
 				rtt_us = jiffies_to_usecs(ca_seq_rtt);
 
 			ca_ops->pkts_acked(sk, pkts_acked, rtt_us);
@@ -2217,8 +2220,8 @@ void serval_tcp_parse_options(struct sk_buff *skb,
 				break;
 			case TCPOPT_WINDOW:
 				if (opsize == TCPOLEN_WINDOW && th->syn &&
-					!estab &&
-					sysctl_serval_tcp_window_scaling) {
+				    !estab &&
+				    sysctl_serval_tcp_window_scaling) {
 					__u8 snd_wscale = *(__u8 *)ptr;
 					opt_rx->wscale_ok = 1;
 					if (snd_wscale > 14) {
@@ -2232,10 +2235,8 @@ void serval_tcp_parse_options(struct sk_buff *skb,
 				break;
 			case TCPOPT_TIMESTAMP:
 				if ((opsize == TCPOLEN_TIMESTAMP) &&
-					((estab && opt_rx->tstamp_ok) ||
-						(!estab &&
-						sysctl_serval_tcp_timestamps))
-					) {
+				    ((estab && opt_rx->tstamp_ok) ||
+				    (!estab && sysctl_serval_tcp_timestamps))) {
 					opt_rx->saw_tstamp = 1;
 					opt_rx->rcv_tsval =
 						get_unaligned_be32(ptr);
@@ -2655,7 +2656,7 @@ static void serval_tcp_data_queue(struct sock *sk, struct sk_buff *skb)
 
 			local_bh_enable();
 			if (!skb_copy_datagram_iovec(skb, 0, tp->ucopy.iov,
-				chunk)) {
+						     chunk)) {
 				tp->ucopy.len -= chunk;
 				tp->copied_seq += chunk;
 				eaten = (chunk == skb->len && !th->fin);
@@ -3008,7 +3009,7 @@ static void serval_tcp_collapse_ofo_queue(struct sock *sk)
 		    after(TCP_SKB_CB(skb)->seq, end) ||
 		    before(TCP_SKB_CB(skb)->end_seq, start)) {
 			serval_tcp_collapse(sk, &tp->out_of_order_queue,
-				     head, skb, start, end);
+					    head, skb, start, end);
 			head = skb;
 			if (!skb)
 				break;
@@ -3306,7 +3307,7 @@ static __sum16 __serval_tcp_checksum_complete_user(struct sock *sk,
 }
 
 static inline int serval_tcp_checksum_complete_user(struct sock *sk,
-					     struct sk_buff *skb)
+						    struct sk_buff *skb)
 {
 	return !skb_csum_unnecessary(skb) &&
 		__serval_tcp_checksum_complete_user(sk, skb);
@@ -3357,11 +3358,11 @@ int serval_tcp_rcv_state_process(struct sock *sk, struct sk_buff *skb,
 					int tmo;
 #if 0
 					if (tp->linger2 < 0 ||
-						(TCP_SKB_CB(skb)->end_seq !=
-							TCP_SKB_CB(skb)->seq &&
-						after(TCP_SKB_CB(skb)->end_seq
-							- th->fin,
-							tp->rcv_nxt))) {
+					    (TCP_SKB_CB(skb)->end_seq !=
+					    TCP_SKB_CB(skb)->seq &&
+					    after(TCP_SKB_CB(skb)->end_seq
+						  - th->fin,
+						  tp->rcv_nxt))) {
 						/* TCP Done! */
 						serval_sal_done(sk);
 
@@ -3424,8 +3425,8 @@ int serval_tcp_rcv_state_process(struct sock *sk, struct sk_buff *skb,
 		 */
 		if (sk->sk_shutdown & RCV_SHUTDOWN) {
 			if (TCP_SKB_CB(skb)->end_seq != TCP_SKB_CB(skb)->seq &&
-				after(TCP_SKB_CB(skb)->end_seq - th->fin,
-					tp->rcv_nxt)) {
+			    after(TCP_SKB_CB(skb)->end_seq - th->fin,
+				  tp->rcv_nxt)) {
 				/* Received seqno after rcv_nxt.
 				 * Handling as RESET.
 				 */
@@ -3911,7 +3912,8 @@ int serval_tcp_syn_sent_state_process(struct sock *sk, struct sk_buff *skb)
 			serval_tcp_incr_quickack(sk);
 			serval_tcp_enter_quickack_mode(sk);
 			serval_tsk_reset_xmit_timer(sk, STSK_TIME_DACK,
-				TCP_DELACK_MAX, SERVAL_TCP_RTO_MAX);
+						    TCP_DELACK_MAX,
+						    SERVAL_TCP_RTO_MAX);
 		}
 	} else {
 		/* No ACK in TCP message received in SYN-SENT state. */

--- a/net/xia/ppal_serval/serval_tcp_input.c
+++ b/net/xia/ppal_serval/serval_tcp_input.c
@@ -392,9 +392,7 @@ static inline void serval_tcp_rcv_rtt_measure_ts(struct sock *sk,
 					  0);
 }
 
-/*
-
- * This function should be called every time data is copied to user space.
+/* This function should be called every time data is copied to user space.
  * It calculates the appropriate TCP receive buffer space.
  */
 void serval_tcp_rcv_space_adjust(struct sock *sk)
@@ -744,16 +742,12 @@ static void serval_tcp_cwnd_down(struct sock *sk, int flag)
 }
 
 
-/*
- * Packet counting of FACK is based on in-order assumptions, therefore
- * TCP disables it when reordering is detected
+/* Packet counting of FACK is based on in-order assumptions, therefore
+ * TCP disables it when reordering is detected.
  */
 void serval_tcp_disable_fack(struct serval_tcp_sock *tp)
 {
-	/* RFC3517 uses different metric in lost marker => reset on
-	 * change.
-	 */
-
+	/* RFC3517 uses different metric in lost marker => reset on change. */
 	if (serval_tcp_is_fack(tp))
 		tp->lost_skb_hint = NULL;
 
@@ -880,7 +874,8 @@ void serval_tcp_enter_loss(struct sock *sk, int how)
 
 	if (!how) {
 		/* Push undo marker, if it was plain RTO and nothing
-		 * was retransmitted. */
+		 * was retransmitted.
+		 */
 		tp->undo_marker = tp->snd_una;
 	} else {
 		tp->sacked_out = 0;
@@ -990,7 +985,8 @@ static int serval_tcp_try_undo_recovery(struct sock *sk)
 	if (tp->snd_una == tp->high_seq && serval_tcp_is_reno(tp)) {
 		/* Hold old state until something *above* high_seq
 		 * is ACKed. For Reno it is MUST to prevent false
-		 * fast retransmits (RFC2582). SACK TCP is safe. */
+		 * fast retransmits (RFC2582). SACK TCP is safe.
+		 */
 		serval_tcp_moderate_cwnd(tp);
 		return 1;
 	}
@@ -1507,7 +1503,8 @@ static void serval_tcp_fastretrans_alert(struct sock *sk,
 		tp->fackets_out = 0;
 
 	/* Now state machine starts.
-	 * A. ECE, hence prohibit cwnd undoing, the reduction is required. */
+	 * A. ECE, hence prohibit cwnd undoing, the reduction is required.
+	 */
 	if (flag & FLAG_ECE)
 		tp->prior_ssthresh = 0;
 
@@ -1529,7 +1526,8 @@ static void serval_tcp_fastretrans_alert(struct sock *sk,
 	serval_tcp_verify_left_out(tp);
 
 	/* E. Check state exit conditions. State can be terminated
-	 *    when high_seq is ACKed. */
+	 *    when high_seq is ACKed.
+	 */
 	if (tp->ca_state == TCP_CA_Open) {
 		WARN_ON(tp->retrans_out != 0);
 		tp->retrans_stamp = 0;
@@ -1543,7 +1541,8 @@ static void serval_tcp_fastretrans_alert(struct sock *sk,
 
 		case TCP_CA_CWR:
 			/* CWR is to be held something *above* high_seq
-			 * is ACKed for CWR bit to reach receiver. */
+			 * is ACKed for CWR bit to reach receiver.
+			 */
 			if (tp->snd_una != tp->high_seq) {
 				serval_tcp_complete_cwr(sk);
 				serval_tcp_set_ca_state(sk, TCP_CA_Open);
@@ -1554,7 +1553,8 @@ static void serval_tcp_fastretrans_alert(struct sock *sk,
 			serval_tcp_try_undo_dsack(sk);
 			if (!tp->undo_marker ||
 			    /* For SACK case do not Open to allow to undo
-			     * catching for all duplicate ACKs. */
+			     * catching for all duplicate ACKs.
+			     */
 			    serval_tcp_is_reno(tp) ||
 			    tp->snd_una != tp->high_seq) {
 				tp->undo_marker = 0;
@@ -1748,7 +1748,8 @@ static inline void serval_tcp_ack_update_rtt(struct sock *sk, const int flag,
 {
 	const struct serval_tcp_sock *tp = serval_tcp_sk(sk);
 	/* Note that peer MAY send zero echo. In this case it is
-	 * ignored. (rfc1323) */
+	 * ignored. (rfc1323).
+	 */
 	if (tp->rx_opt.saw_tstamp && tp->rx_opt.rcv_tsecr)
 		serval_tcp_ack_saw_tstamp(sk, flag);
 	else if (seq_rtt >= 0)
@@ -1886,7 +1887,8 @@ static int serval_tcp_clean_rtx_queue(struct sock *sk,
 		u8 sacked = scb->sacked;
 
 		/* Determine how many packets and what bytes were
-		 * acked, tso and else */
+		 * acked, tso and else.
+		 */
 		if (after(scb->end_seq, tp->snd_una)) {
 			if (serval_tcp_skb_pcount(skb) == 1 ||
 			    !after(tp->snd_una, scb->seq))
@@ -2375,9 +2377,7 @@ static inline void serval_tcp_data_snd_check(struct sock *sk)
 	serval_tcp_check_space(sk);
 }
 
-/*
- * Check if sending an ack is needed.
- */
+/* Check if sending an ack is needed. */
 static void __serval_tcp_ack_snd_check(struct sock *sk, int ofo_possible)
 {
 	struct serval_tcp_sock *tp = serval_tcp_sk(sk);
@@ -2522,19 +2522,18 @@ static void serval_tcp_dsack_extend(struct sock *sk, u32 seq, u32 end_seq)
 
 #endif /* ENABLE_TCP_SACK */
 
-/*
- *	Process the FIN bit. This now behaves as it is supposed to work
- *	and the FIN takes effect when it is validly part of sequence
- *	space. Not before when we get holes.
+/* Process the FIN bit. This now behaves as it is supposed to work
+ * and the FIN takes effect when it is validly part of sequence
+ * space. Not before when we get holes.
  *
- *	If we are ESTABLISHED, a received fin moves us to CLOSE-WAIT
- *	(and thence onto LAST-ACK and finally, CLOSE, we never enter
- *	TIME-WAIT)
+ * If we are ESTABLISHED, a received fin moves us to CLOSE-WAIT
+ * (and thence onto LAST-ACK and finally, CLOSE, we never enter
+ * TIME-WAIT)
  *
- *	If we are in FINWAIT-1, a received FIN indicates simultaneous
- *	close and we go into CLOSING (and later onto TIME-WAIT)
+ * If we are in FINWAIT-1, a received FIN indicates simultaneous
+ * close and we go into CLOSING (and later onto TIME-WAIT)
  *
- *	If we are in FINWAIT-2, a received FIN moves us to TIME-WAIT.
+ * If we are in FINWAIT-2, a received FIN moves us to TIME-WAIT.
  */
 static void serval_tcp_fin(struct sk_buff *skb,
 			   struct sock *sk, struct tcphdr *th)
@@ -2884,7 +2883,8 @@ static void serval_tcp_collapse(struct sock *sk, struct sk_buff_head *list,
 	int end_of_skbs;
 
 	/* First, check that queue is collapsible and find
-	 * the point where collapsing can be useful. */
+	 * the point where collapsing can be useful.
+	 */
 	skb = head;
 restart:
 	end_of_skbs = 1;
@@ -3004,7 +3004,8 @@ static void serval_tcp_collapse_ofo_queue(struct sock *sk)
 		skb = next;
 
 		/* Segment is terminated when we see gap or when
-		 * we are at the end of all the queue. */
+		 * we are at the end of all the queue.
+		 */
 		if (!skb ||
 		    after(TCP_SKB_CB(skb)->seq, end) ||
 		    before(TCP_SKB_CB(skb)->end_seq, start)) {
@@ -3013,7 +3014,7 @@ static void serval_tcp_collapse_ofo_queue(struct sock *sk)
 			head = skb;
 			if (!skb)
 				break;
-			/* Start new segment */
+			/* Start new segment. */
 			start = TCP_SKB_CB(skb)->seq;
 			end = TCP_SKB_CB(skb)->end_seq;
 		} else {
@@ -3025,10 +3026,7 @@ static void serval_tcp_collapse_ofo_queue(struct sock *sk)
 	}
 }
 
-/*
- * Purge the out-of-order queue.
- * Return true if queue was pruned.
- */
+/* Purge the out-of-order queue. Return true if queue was pruned. */
 static int serval_tcp_prune_ofo_queue(struct sock *sk)
 {
 	struct serval_tcp_sock *tp = serval_tcp_sk(sk);
@@ -3084,7 +3082,8 @@ static int serval_tcp_prune_queue(struct sock *sk)
 		return 0;
 
 	/* Collapsing did not help, destructive actions follow.
-	 * This must not ever occur. */
+	 * This must not ever occur.
+	 */
 
 	serval_tcp_prune_ofo_queue(sk);
 
@@ -3108,8 +3107,7 @@ static void serval_tcp_send_dupack(struct sock *sk, struct sk_buff *skb)
 
 	if (TCP_SKB_CB(skb)->end_seq != TCP_SKB_CB(skb)->seq &&
 	    before(TCP_SKB_CB(skb)->seq, tp->rcv_nxt)) {
-		/* NET_INC_STATS_BH(sock_net(sk),
-			LINUX_MIB_DELAYEDACKLOST); */
+		/* NET_INC_STATS_BH(sock_net(sk), LINUX_MIB_DELAYEDACKLOST); */
 		serval_tcp_enter_quickack_mode(sk);
 
 		/*
@@ -3210,7 +3208,8 @@ static int serval_tcp_validate_incoming(struct sock *sk, struct sk_buff *skb,
 	    serval_tcp_paws_discard(sk, skb)) {
 		if (!th->rst) {
 			/* NET_INC_STATS_BH(sock_net(sk),
-				LINUX_MIB_PAWSESTABREJECTED); */
+				LINUX_MIB_PAWSESTABREJECTED);
+			*/
 			serval_tcp_send_dupack(sk, skb);
 			goto discard;
 		}
@@ -3250,7 +3249,8 @@ static int serval_tcp_validate_incoming(struct sock *sk, struct sk_buff *skb,
 
 	/* step 4: Check for a SYN in window. */
 	if (th->syn && !before(TCP_SKB_CB(skb)->seq, tp->rcv_nxt)) {
-		/* if (syn_inerr)
+		/*
+		if (syn_inerr)
 			TCP_INC_STATS_BH(sock_net(sk), TCP_MIB_INERRS);
 		NET_INC_STATS_BH(sock_net(sk), LINUX_MIB_TCPABORTONSYN);
 		*/
@@ -3313,13 +3313,11 @@ static inline int serval_tcp_checksum_complete_user(struct sock *sk,
 		__serval_tcp_checksum_complete_user(sk, skb);
 }
 
-/*
- *	This function implements the receiving procedure of RFC 793 for
- *	all states except ESTABLISHED and TIME_WAIT.
- *	It's called from both tcp_v4_rcv and tcp_v6_rcv and should be
- *	address independent.
+/* This function implements the receiving procedure of RFC 793 for
+ * all states except ESTABLISHED and TIME_WAIT.
+ * It's called from both tcp_v4_rcv and tcp_v6_rcv and should be
+ * address independent.
  */
-
 int serval_tcp_rcv_state_process(struct sock *sk, struct sk_buff *skb,
 				 struct tcphdr *th, unsigned len)
 {
@@ -3456,13 +3454,12 @@ discard:
 	return 0;
 }
 
-/*
- *	TCP receive function for the ESTABLISHED state.
+/* TCP receive function for the ESTABLISHED state.
  *
- *	It is split into a fast path and a slow path. The fast path is
- *	disabled when:
+ * It is split into a fast path and a slow path. The fast path is
+ * disabled when:
  *	- A zero window was announced from us - zero window probing
- *	is only handled properly in the slow path.
+ *	  is only handled properly in the slow path.
  *	- Out of order segments arrived.
  *	- Urgent data is expected.
  *	- There is no buffer space left
@@ -3473,11 +3470,11 @@ discard:
  *	  value must stay constant)
  *	- Unexpected TCP option.
  *
- *	When these conditions are not satisfied it drops into a standard
- *	receive procedure patterned after RFC793 to handle all cases.
- *	The first three cases are guaranteed by proper pred_flags setting,
- *	the rest is checked inline. Fast processing is turned on in
- *	tcp_data_queue when everything is OK.
+ * When these conditions are not satisfied it drops into a standard
+ * receive procedure patterned after RFC793 to handle all cases.
+ * The first three cases are guaranteed by proper pred_flags setting,
+ * the rest is checked inline. Fast processing is turned on in
+ * tcp_data_queue when everything is OK.
  */
 int serval_tcp_rcv_established(struct sock *sk, struct sk_buff *skb,
 			       struct tcphdr *th, unsigned len)
@@ -3485,30 +3482,29 @@ int serval_tcp_rcv_established(struct sock *sk, struct sk_buff *skb,
 	struct serval_tcp_sock *tp = serval_tcp_sk(sk);
 	int res;
 
-	/*
-	 *	Header prediction.
-	 *	The code loosely follows the one in the famous
-	 *	"30 instruction TCP receive" Van Jacobson mail.
+	/* Header prediction.
+	 * The code loosely follows the one in the famous
+	 * "30 instruction TCP receive" Van Jacobson mail.
 	 *
-	 *	Van's trick is to deposit buffers into socket queue
-	 *	on a device interrupt, to call tcp_recv function
-	 *	on the receive process context and checksum and copy
-	 *	the buffer to user space. smart...
+	 * Van's trick is to deposit buffers into socket queue
+	 * on a device interrupt, to call tcp_recv function
+	 * on the receive process context and checksum and copy
+	 * the buffer to user space. smart...
 	 *
-	 *	Our current scheme is not silly either but we take the
-	 *	extra cost of the net_bh soft interrupt processing...
-	 *	We do checksum and copy also but from device to kernel.
+	 * Our current scheme is not silly either but we take the
+	 * extra cost of the net_bh soft interrupt processing...
+	 * We do checksum and copy also but from device to kernel.
 	 */
 
 	tp->rx_opt.saw_tstamp = 0;
 
-	/*	pred_flags is 0xS?10 << 16 + snd_wnd
-	 *	if header_prediction is to be made
-	 *	'S' will always be tp->tcp_header_len >> 2
-	 *	'?' will be 0 for the fast path, otherwise pred_flags is 0 to
-	 *  turn it off	(when there are holes in the receive
-	 *	 space for instance)
-	 *	PSH flag is ignored.
+	/* pred_flags is 0xS?10 << 16 + snd_wnd
+	 * if header_prediction is to be made
+	 * 'S' will always be tp->tcp_header_len >> 2
+	 * '?' will be 0 for the fast path, otherwise pred_flags is 0 to
+	 * turn it off (when there are holes in the receive
+	 *  space for instance)
+	 * PSH flag is ignored.
 	 */
 
 	tp->bytes_queued += len;
@@ -3566,8 +3562,9 @@ int serval_tcp_rcv_established(struct sock *sk, struct sk_buff *skb,
 				serval_tcp_data_snd_check(sk);
 				return 0;
 			} else { /* Header too small */
-				/* TCP_INC_STATS_BH(sock_net(sk),
-					TCP_MIB_INERRS); */
+				/*
+				TCP_INC_STATS_BH(sock_net(sk), TCP_MIB_INERRS);
+				*/
 				goto discard;
 			}
 		} else {
@@ -3608,8 +3605,10 @@ int serval_tcp_rcv_established(struct sock *sk, struct sk_buff *skb,
 
 					__skb_pull(skb, tcp_header_len);
 					tp->rcv_nxt = TCP_SKB_CB(skb)->end_seq;
-					/* NET_INC_STATS_BH(sock_net(sk),
-						LINUX_MIB_TCPHPHITSTOUSER); */
+					/*
+					NET_INC_STATS_BH(sock_net(sk),
+						LINUX_MIB_TCPHPHITSTOUSER);
+					*/
 				}
 				if (copied_early)
 					serval_tcp_cleanup_rbuf(sk, skb->len);
@@ -3631,10 +3630,12 @@ int serval_tcp_rcv_established(struct sock *sk, struct sk_buff *skb,
 				if ((int)skb->truesize > sk->sk_forward_alloc)
 					goto step5;
 
-				/* NET_INC_STATS_BH(sock_net(sk),
-					LINUX_MIB_TCPHPHITS); */
+				/*
+				NET_INC_STATS_BH(sock_net(sk),
+					LINUX_MIB_TCPHPHITS);
+				*/
 
-				/* Bulk data transfer: receiver */
+				/* Bulk data transfer: receiver. */
 				__skb_pull(skb, tcp_header_len);
 				__skb_queue_tail(&sk->sk_receive_queue, skb);
 				skb_set_owner_r(skb, sk);
@@ -3680,9 +3681,7 @@ slow_path:
 	if (serval_tcp_checksum_complete_user(sk, skb))
 		goto csum_error;
 
-	/*
-	 *	Standard slow path.
-	 */
+	/* Standard slow path. */
 
 	res = serval_tcp_validate_incoming(sk, skb, th, 1);
 
@@ -3715,8 +3714,6 @@ discard:
 	return 0;
 }
 
-/*
- */
 int serval_tcp_syn_recv_state_process(struct sock *sk, struct sk_buff *skb)
 {
 	struct tcphdr *th;
@@ -3859,7 +3856,8 @@ int serval_tcp_syn_sent_state_process(struct sock *sk, struct sk_buff *skb)
 
 		/* Remember, tcp_poll() does not lock socket!
 		 * Change state from SYN-SENT only after copied_seq
-		 * is initialized. */
+		 * is initialized.
+		 */
 		tp->copied_seq = tp->rcv_nxt;
 
 		smp_mb();
@@ -3888,8 +3886,8 @@ int serval_tcp_syn_sent_state_process(struct sock *sk, struct sk_buff *skb)
 		else
 			tp->pred_flags = 0;
 
+		/* Waking should be handled in SAL. */
 		/*
-		  Waking should be handled in SAL
 		if (!sock_flag(sk, SOCK_DEAD)) {
 			sk->sk_state_change(sk);
 			sk_wake_async(sk, SOCK_WAKE_IO, POLL_OUT);

--- a/net/xia/ppal_serval/serval_tcp_input.c
+++ b/net/xia/ppal_serval/serval_tcp_input.c
@@ -44,7 +44,6 @@ int sysctl_serval_tcp_max_orphans __read_mostly = 1;
 #define TCP_REMNANT (TCP_FLAG_FIN|TCP_FLAG_URG|TCP_FLAG_SYN|TCP_FLAG_PSH)
 #define TCP_HP_BITS (~(TCP_RESERVED_BITS|TCP_FLAG_PSH))
 
-
 /* Adapt the MSS value used to make delayed ack decision to the
  * real world.
  */
@@ -94,7 +93,6 @@ static void serval_tcp_measure_rcv_mss(struct sock *sk,
 		tp->tp_ack.pending |= STSK_ACK_PUSHED;
 	}
 }
-
 
 /* Buffer size and advertised window tuning.
  *
@@ -180,10 +178,7 @@ static void serval_tcp_grow_window(struct sock *sk, struct sk_buff *skb)
 	}
 }
 
-
-
 /* 3. Tuning rcvbuf, when connection enters established state. */
-
 static void serval_tcp_fixup_rcvbuf(struct sock *sk)
 {
 	struct serval_tcp_sock *tp = serval_tcp_sk(sk);
@@ -236,7 +231,6 @@ static void serval_tcp_init_buffer_space(struct sock *sk)
 	tp->snd_cwnd_stamp = tcp_time_stamp;
 }
 
-
 /* 5. Recalculate window clamp after socket hit its memory bounds. */
 static void serval_tcp_clamp_window(struct sock *sk)
 {
@@ -267,10 +261,10 @@ static void serval_tcp_incr_quickack(struct sock *sk)
 		tp->tp_ack.quick = min(quickacks, TCP_MAX_QUICKACKS);
 }
 
-
 void serval_tcp_enter_quickack_mode(struct sock *sk)
 {
 	struct serval_tcp_sock *tp = serval_tcp_sk(sk);
+
 	serval_tcp_incr_quickack(sk);
 	tp->tp_ack.pingpong = 0;
 	tp->tp_ack.ato = TCP_ATO_MIN;
@@ -285,7 +279,6 @@ static inline int serval_tcp_in_quickack_mode(const struct sock *sk)
 	const struct serval_tcp_sock *tp = serval_tcp_sk(sk);
 	return tp->tp_ack.quick && !tp->tp_ack.pingpong;
 }
-
 
 static void serval_tcp_clear_retrans_partial(struct serval_tcp_sock *tp)
 {
@@ -385,6 +378,7 @@ static inline void serval_tcp_rcv_rtt_measure_ts(struct sock *sk,
 						 struct sk_buff *skb)
 {
 	struct serval_tcp_sock *tp = serval_tcp_sk(sk);
+
 	if (tp->rx_opt.rcv_tsecr && (TCP_SKB_CB(skb)->end_seq -
 		TCP_SKB_CB(skb)->seq >= tp->tp_ack.rcv_mss))
 		serval_tcp_rcv_rtt_update(tp,
@@ -447,7 +441,6 @@ new_measure:
 	tp->rcvq_space.seq = tp->copied_seq;
 	tp->rcvq_space.time = tcp_time_stamp;
 }
-
 
 /* There is something which you must keep in mind when you analyze the
  * behavior of the tp->ato delayed ack timeout interval.  When a
@@ -527,7 +520,6 @@ __u32 serval_tcp_init_cwnd(struct serval_tcp_sock *tp, struct dst_entry *dst)
 	return min_t(__u32, cwnd, tp->snd_cwnd_clamp);
 }
 
-
 /* Set slow start threshold and cwnd not falling to slow start */
 void serval_tcp_enter_cwr(struct sock *sk, const int set_ssthresh)
 {
@@ -563,6 +555,7 @@ void serval_tcp_cwnd_application_limited(struct sock *sk)
 		/* Limited by application or receiver window. */
 		u32 init_win = serval_tcp_init_cwnd(tp, __sk_dst_get(sk));
 		u32 win_used = max(tp->snd_cwnd_used, init_win);
+
 		if (win_used < tp->snd_cwnd) {
 			tp->snd_ssthresh = serval_tcp_current_ssthresh(sk);
 			tp->snd_cwnd = (tp->snd_cwnd + win_used) >> 1;
@@ -644,12 +637,14 @@ static void serval_tcp_rtt_estimator(struct sock *sk, const __u32 mrtt)
 		tp->rtt_seq = tp->snd_nxt;
 	}
 }
+
 /* Calculate rto without backoff.  This is the second half of Van Jacobson's
  * routine referred to above.
  */
 void serval_tcp_set_rto(struct sock *sk)
 {
 	struct serval_tcp_sock *tp = serval_tcp_sk(sk);
+
 	/* Old crap is replaced with new one. 8)
 	 *
 	 * More seriously:
@@ -741,7 +736,6 @@ static void serval_tcp_cwnd_down(struct sock *sk, int flag)
 	}
 }
 
-
 /* Packet counting of FACK is based on in-order assumptions, therefore
  * TCP disables it when reordering is detected.
  */
@@ -776,6 +770,7 @@ static void serval_tcp_update_reordering(struct sock *sk,
 					 const int ts)
 {
 	struct serval_tcp_sock *tp = serval_tcp_sk(sk);
+
 	if (metric > tp->reordering) {
 		/* int mib_idx; */
 
@@ -799,7 +794,6 @@ static void serval_tcp_update_reordering(struct sock *sk,
 	}
 }
 
-
 /* If we receive more dupacks than we expected counting segments
  * in assumption of absent reordering, interpret this as reordering.
  * The only another reason could be bug in receiver TCP.
@@ -808,20 +802,20 @@ static void serval_tcp_check_reno_reordering(struct sock *sk,
 					     const int addend)
 {
 	struct serval_tcp_sock *tp = serval_tcp_sk(sk);
+
 	if (serval_tcp_limit_reno_sacked(tp))
 		serval_tcp_update_reordering(sk, tp->packets_out + addend, 0);
 }
 
 /* Emulate SACKs for SACKless connection: account for a new dupack. */
-
 static void serval_tcp_add_reno_sack(struct sock *sk)
 {
 	struct serval_tcp_sock *tp = serval_tcp_sk(sk);
+
 	tp->sacked_out++;
 	serval_tcp_check_reno_reordering(sk, 0);
 	serval_tcp_verify_left_out(tp);
 }
-
 
 /* Account for ACK, ACKing some data in Reno Recovery phase. */
 static void serval_tcp_remove_reno_sacks(struct sock *sk, int acked)
@@ -843,8 +837,6 @@ static inline void serval_tcp_reset_reno_sack(struct serval_tcp_sock *tp)
 {
 	tp->sacked_out = 0;
 }
-
-
 
 /* Enter Loss state. If "how" is not zero, forget all SACK information
  * and reset tags completely, otherwise preserve SACKs. If receiver
@@ -1033,6 +1025,7 @@ static int serval_tcp_try_undo_loss(struct sock *sk)
 
 	if (serval_tcp_may_undo(tp)) {
 		struct sk_buff *skb;
+
 		serval_tcp_for_write_queue(skb, sk) {
 			if (skb == serval_tcp_send_head(sk))
 				break;
@@ -1057,11 +1050,11 @@ static int serval_tcp_try_undo_loss(struct sock *sk)
 static inline void serval_tcp_complete_cwr(struct sock *sk)
 {
 	struct serval_tcp_sock *tp = serval_tcp_sk(sk);
+
 	tp->snd_cwnd = min(tp->snd_cwnd, tp->snd_ssthresh);
 	tp->snd_cwnd_stamp = tcp_time_stamp;
 	serval_tcp_ca_event(sk, CA_EVENT_COMPLETE_CWR);
 }
-
 
 /* Try to undo cwnd reduction, because D-SACKs acked all retransmitted data. */
 static void serval_tcp_try_undo_dsack(struct sock *sk)
@@ -1231,7 +1224,6 @@ static inline int serval_tcp_head_timedout(struct sock *sk)
 		serval_tcp_skb_timedout(sk, serval_tcp_write_queue_head(sk));
 }
 
-
 /* New heuristics: it is possible only after we switched to restart
  * timer each time when something is ACKed. Hence, we can detect timed
  * out packets during fast retransmit without falling to slow start.
@@ -1269,7 +1261,6 @@ static void serval_tcp_timeout_skbs(struct sock *sk)
 
 	serval_tcp_verify_left_out(tp);
 }
-
 
 /* Mark head of queue up as lost. With RFC3517 SACK, the packets is
  * is against sacked "cnt", otherwise it's against facked "cnt"
@@ -1346,11 +1337,13 @@ static void serval_tcp_update_scoreboard(struct sock *sk,
 		serval_tcp_mark_head_lost(sk, 1, 1);
 	} else if (serval_tcp_is_fack(tp)) {
 		int lost = tp->fackets_out - tp->reordering;
+
 		if (lost <= 0)
 			lost = 1;
 		serval_tcp_mark_head_lost(sk, lost, 0);
 	} else {
 		int sacked_upto = tp->sacked_out - tp->reordering;
+
 		if (sacked_upto >= 0)
 			serval_tcp_mark_head_lost(sk, sacked_upto, 0);
 		else if (fast_rexmit)
@@ -1416,7 +1409,6 @@ static int serval_tcp_time_to_recover(struct sock *sk)
 
 	return 0;
 }
-
 
 /* I wish gso_size would have a bit more sane initialization than
  * something-or-zero which complicates things
@@ -1700,7 +1692,6 @@ static u32 serval_tcp_tso_acked(struct sock *sk, struct sk_buff *skb)
 	return packets_acked;
 }
 
-
 /* Read draft-ietf-tcplw-high-performance before mucking
  * with this code. (Supersedes RFC1323)
  */
@@ -1755,7 +1746,6 @@ static inline void serval_tcp_ack_update_rtt(struct sock *sk, const int flag,
 	else if (seq_rtt >= 0)
 		serval_tcp_ack_no_tstamp(sk, seq_rtt, flag);
 }
-
 
 static void serval_tcp_ack_probe(struct sock *sk)
 {
@@ -2019,6 +2009,7 @@ static int serval_tcp_clean_rtx_queue(struct sock *sk,
 static void serval_tcp_cong_avoid(struct sock *sk, u32 ack, u32 in_flight)
 {
 	struct serval_tcp_sock *tp = serval_tcp_sk(sk);
+
 	tp->ca_ops->cong_avoid(sk, ack, in_flight);
 	tp->snd_cwnd_stamp = tcp_time_stamp;
 }
@@ -2130,6 +2121,7 @@ static int serval_tcp_ack(struct sock *sk, struct sk_buff *skb, int flag)
 
 	if ((flag & FLAG_FORWARD_PROGRESS) || !(flag & FLAG_NOT_DUP)) {
 		struct dst_entry *dst = __sk_dst_get(sk);
+
 		if (dst)
 			dst_confirm(dst);
 	}
@@ -2175,7 +2167,6 @@ static int serval_tcp_parse_aligned_timestamp(struct serval_tcp_sock *tp,
 	return 0;
 }
 
-
 /* Look for tcp options. Normally only called on SYN and SYNACK packets.
  * But, this can also be called on packets in the established flow when
  * the fast version below fails.
@@ -2212,6 +2203,7 @@ void serval_tcp_parse_options(struct sk_buff *skb,
 				if (opsize == TCPOLEN_MSS &&
 				    th->syn && !estab) {
 					u16 in_mss = get_unaligned_be16(ptr);
+
 					if (in_mss) {
 						if (opt_rx->user_mss &&
 						    opt_rx->user_mss < in_mss)
@@ -2225,6 +2217,7 @@ void serval_tcp_parse_options(struct sk_buff *skb,
 				    !estab &&
 				    sysctl_serval_tcp_window_scaling) {
 					__u8 snd_wscale = *(__u8 *)ptr;
+
 					opt_rx->wscale_ok = 1;
 					if (snd_wscale > 14) {
 						/* Received illegal window
@@ -2309,7 +2302,6 @@ void serval_tcp_parse_options(struct sk_buff *skb,
 		}
 	}
 }
-
 
 static int serval_tcp_should_expand_sndbuf(struct sock *sk)
 {
@@ -2437,7 +2429,6 @@ static int serval_tcp_fast_parse_options(struct sk_buff *skb,
 	return 1;
 }
 
-
 static inline void serval_tcp_store_ts_recent(struct serval_tcp_sock *tp)
 {
 	tp->rx_opt.ts_recent = tp->rx_opt.rcv_tsval;
@@ -2473,11 +2464,11 @@ static inline int serval_tcp_paws_discard(const struct sock *sk,
 
 #endif /* ENABLE_TCP_PAWS */
 
-
 static void serval_tcp_dsack_set(struct sock *sk, u32 seq, u32 end_seq)
 {
 #if defined(ENABLE_TCP_SACK)
 	struct serval_tcp_sock *tp = serval_tcp_sk(sk);
+
 	if (serval_tcp_is_sack(tp) && sysctl_tcp_dsack) {
 		/*
 		int mib_idx;
@@ -2697,7 +2688,6 @@ queue_and_out:
 		if (eaten > 0) {
 			__kfree_skb(skb);
 		} else if (!sock_flag(sk, SOCK_DEAD)) {
-
 			sk->sk_data_ready(sk);
 		}
 		return;
@@ -2913,6 +2903,7 @@ restart:
 
 		if (!skb_queue_is_last(list, skb)) {
 			struct sk_buff *next = skb_queue_next(list, skb);
+
 			if (next != tail &&
 			    TCP_SKB_CB(skb)->end_seq != TCP_SKB_CB(next)->seq) {
 				end_of_skbs = 0;
@@ -3124,7 +3115,6 @@ static void serval_tcp_send_dupack(struct sock *sk, struct sk_buff *skb)
 	serval_tcp_send_ack(sk);
 }
 
-
 /* Check segment sequence number for validity.
  *
  * Segment controls are considered valid, if the segment
@@ -3137,7 +3127,6 @@ static void serval_tcp_send_dupack(struct sock *sk, struct sk_buff *skb)
  * delayed ACK, so that hisSND.UNA<=ourRCV.WUP.
  * (borrowed from freebsd)
  */
-
 static inline int serval_tcp_sequence(struct serval_tcp_sock *tp,
 				      u32 seq, u32 end_seq)
 {
@@ -3348,6 +3337,7 @@ int serval_tcp_rcv_state_process(struct sock *sk, struct sk_buff *skb,
 		case TCP_FIN_WAIT1:
 			if (tp->snd_una == tp->write_seq) {
 				struct dst_entry *dst;
+
 				dst = __sk_dst_get(sk);
 				if (dst)
 					dst_confirm(dst);

--- a/net/xia/ppal_serval/serval_tcp_input.c
+++ b/net/xia/ppal_serval/serval_tcp_input.c
@@ -633,8 +633,8 @@ static void serval_tcp_rtt_estimator(struct sock *sk, const __u32 mrtt)
 		/* no previous measure. */
 		tp->srtt = m << 3;	/* take the measured time to be rtt */
 		tp->mdev = m << 1;	/* make sure rto = 3*rtt */
-		tp->mdev_max = tp->rttvar = max(tp->mdev,
-						serval_tcp_rto_min(sk));
+		tp->rttvar = max(tp->mdev, serval_tcp_rto_min(sk));
+		tp->mdev_max = tp->rttvar;
 		tp->rtt_seq = tp->snd_nxt;
 	}
 }
@@ -3814,7 +3814,8 @@ int serval_tcp_syn_sent_state_process(struct sock *sk, struct sk_buff *skb)
 
 		if (!tp->rx_opt.wscale_ok) {
 			/* Window scaling is NOT OK! */
-			tp->rx_opt.snd_wscale = tp->rx_opt.rcv_wscale = 0;
+			tp->rx_opt.rcv_wscale = 0;
+			tp->rx_opt.snd_wscale = 0;
 			tp->window_clamp = min(tp->window_clamp, 65535U);
 		}
 

--- a/net/xia/ppal_serval/serval_tcp_input.c
+++ b/net/xia/ppal_serval/serval_tcp_input.c
@@ -350,8 +350,9 @@ static void serval_tcp_rcv_rtt_update(struct serval_tcp_sock *tp,
 		if (!win_dep) {
 			m -= (new_sample >> 3);
 			new_sample += m;
-		} else if (m < new_sample)
+		} else if (m < new_sample) {
 			new_sample = m << 3;
+		}
 	} else {
 		/* No previous measure. */
 		new_sample = m << 3;
@@ -1570,8 +1571,9 @@ static void serval_tcp_fastretrans_alert(struct sock *sk,
 		if (!(flag & FLAG_SND_UNA_ADVANCED)) {
 			if (serval_tcp_is_reno(tp) && is_dupack)
 				serval_tcp_add_reno_sack(sk);
-		} else
+		} else {
 			do_lost = serval_tcp_try_undo_partial(sk, pkts_acked);
+		}
 		break;
 	case TCP_CA_Loss:
 		if (flag & FLAG_DATA_ACKED)
@@ -2685,11 +2687,10 @@ queue_and_out:
 #endif
 		serval_tcp_fast_path_check(sk);
 
-		if (eaten > 0) {
+		if (eaten > 0)
 			__kfree_skb(skb);
-		} else if (!sock_flag(sk, SOCK_DEAD)) {
+		else if (!sock_flag(sk, SOCK_DEAD))
 			sk->sk_data_ready(sk);
-		}
 		return;
 	}
 

--- a/net/xia/ppal_serval/serval_tcp_input.c
+++ b/net/xia/ppal_serval/serval_tcp_input.c
@@ -927,7 +927,6 @@ static void serval_tcp_undo_cwr(struct sock *sk, const int undo)
 	struct serval_tcp_sock *tp = serval_tcp_sk(sk);
 
 	if (tp->prior_ssthresh) {
-
 		if (tp->ca_ops->undo_cwnd)
 			tp->snd_cwnd = tp->ca_ops->undo_cwnd(sk);
 		else
@@ -1947,7 +1946,6 @@ static int serval_tcp_clean_rtx_queue(struct sock *sk,
 			tp->retransmit_skb_hint = NULL;
 		if (skb == tp->lost_skb_hint)
 			tp->lost_skb_hint = NULL;
-
 	}
 
 	if (likely(between(tp->snd_up, prior_snd_una, tp->snd_una)))
@@ -2595,15 +2593,12 @@ static inline int serval_tcp_try_rmem_schedule(struct sock *sk,
 {
 	if (atomic_read(&sk->sk_rmem_alloc) > sk->sk_rcvbuf ||
 	    !sk_rmem_schedule(sk, skb, size)) {
-
 		if (serval_tcp_prune_queue(sk) < 0)
 			return -1;
 
 		if (!sk_rmem_schedule(sk, skb, size)) {
-
 			if (!serval_tcp_prune_ofo_queue(sk))
 				return -1;
-
 			if (!sk_rmem_schedule(sk, skb, size))
 				return -1;
 		}
@@ -2700,7 +2695,6 @@ queue_and_out:
 		 */
 
 		/* NET_INC_STATS_BH(sock_net(sk), LINUX_MIB_DELAYEDACKLOST); */
-
 		serval_tcp_dsack_set(sk, TCP_SKB_CB(skb)->seq,
 				     TCP_SKB_CB(skb)->end_seq);
 out_of_window:
@@ -2817,7 +2811,6 @@ drop:
 			if (!after(end_seq, TCP_SKB_CB(skb1)->seq))
 				break;
 			if (before(end_seq, TCP_SKB_CB(skb1)->end_seq)) {
-
 #if defined(ENABLE_TCP_SACK)
 				serval_tcp_dsack_extend(sk,
 							TCP_SKB_CB(skb1)->seq,
@@ -3151,7 +3144,6 @@ static int serval_tcp_dma_try_early_copy(struct sock *sk, struct sk_buff *skb,
 		tp->ucopy.dma_chan = dma_find_channel(DMA_MEMCPY);
 
 	if (tp->ucopy.dma_chan && skb_csum_unnecessary(skb)) {
-
 		dma_cookie = dma_skb_copy_datagram_iovec(tp->ucopy.dma_chan,
 							 skb, hlen,
 							 tp->ucopy.iov, chunk,

--- a/net/xia/ppal_serval/serval_tcp_metrics.c
+++ b/net/xia/ppal_serval/serval_tcp_metrics.c
@@ -46,13 +46,13 @@ static u32 tcp_metric_get_jiffies(struct tcp_metrics_block *tm,
 }
 
 static void tcp_metric_set(struct tcp_metrics_block *tm,
-	enum tcp_metric_index idx, u32 val)
+			   enum tcp_metric_index idx, u32 val)
 {
 	tm->tcpm_vals[idx] = val;
 }
 
 static void tcp_metric_set_msecs(struct tcp_metrics_block *tm,
-	enum tcp_metric_index idx, u32 val)
+				 enum tcp_metric_index idx, u32 val)
 {
 	tm->tcpm_vals[idx] = jiffies_to_msecs(val);
 }
@@ -93,7 +93,8 @@ static void tcpm_suck_dst(struct tcp_metrics_block *tm, struct dst_entry *dst)
 }
 
 static struct tcp_metrics_block *tcpm_new(struct xip_serval_ctx *serval_ctx,
-	struct dst_entry *dst, const __u8 *id, unsigned int hash, bool reclaim)
+					  struct dst_entry *dst, const __u8 *id,
+					  unsigned int hash, bool reclaim)
 {
 	struct tcp_metrics_block *tm;
 
@@ -129,7 +130,7 @@ static struct tcp_metrics_block *tcpm_new(struct xip_serval_ctx *serval_ctx,
 	if (likely(!reclaim)) {
 		tm->tcpm_next = serval_ctx->tcp_metrics_hash[hash].chain;
 		rcu_assign_pointer(serval_ctx->tcp_metrics_hash[hash].chain,
-			tm);
+				   tm);
 	}
 
 out_unlock:
@@ -140,10 +141,10 @@ out_unlock:
 #define TCP_METRICS_TIMEOUT		(60 * 60 * HZ)
 
 static void tcpm_check_stamp(struct tcp_metrics_block *tm,
-	struct dst_entry *dst)
+			     struct dst_entry *dst)
 {
 	if (tm && unlikely(time_after(jiffies,
-		tm->tcpm_stamp + TCP_METRICS_TIMEOUT)))
+				      tm->tcpm_stamp + TCP_METRICS_TIMEOUT)))
 		tcpm_suck_dst(tm, dst);
 }
 
@@ -151,7 +152,7 @@ static void tcpm_check_stamp(struct tcp_metrics_block *tm,
 #define TCP_METRICS_RECLAIM_PTR		((struct tcp_metrics_block *)0x1UL)
 
 static struct tcp_metrics_block *tcp_get_encode(struct tcp_metrics_block *tm,
-	int depth)
+						int depth)
 {
 	if (tm)
 		return tm;
@@ -176,7 +177,8 @@ static struct tcp_metrics_block *__tcp_get_metrics(const __u8 *id,
 }
 
 static struct tcp_metrics_block *tcp_get_metrics(struct sock *sk,
-	struct dst_entry *dst, bool create)
+						 struct dst_entry *dst,
+						 bool create)
 {
 	struct serval_sock *ssk = sk_ssk(sk);
 	const u8 *id;
@@ -299,11 +301,12 @@ void serval_tcp_update_metrics(struct sock *sk)
 		/* Cong. avoidance phase, cwnd is reliable. */
 		if (!tcp_metric_locked(tm, TCP_METRIC_SSTHRESH))
 			tcp_metric_set(tm, TCP_METRIC_SSTHRESH,
-				max(tp->snd_cwnd >> 1, tp->snd_ssthresh));
+				       max(tp->snd_cwnd >> 1,
+					   tp->snd_ssthresh));
 		if (!tcp_metric_locked(tm, TCP_METRIC_CWND)) {
 			val = tcp_metric_get(tm, TCP_METRIC_CWND);
 			tcp_metric_set(tm, TCP_METRIC_CWND,
-				(val + tp->snd_cwnd) >> 1);
+				       (val + tp->snd_cwnd) >> 1);
 		}
 	} else {
 		/* Else slow start did not finish, cwnd is non-sense,

--- a/net/xia/ppal_serval/serval_tcp_metrics.c
+++ b/net/xia/ppal_serval/serval_tcp_metrics.c
@@ -241,9 +241,9 @@ void serval_tcp_update_metrics(struct sock *sk)
 		if (tm && !tcp_metric_locked(tm, TCP_METRIC_RTT))
 			tcp_metric_set(tm, TCP_METRIC_RTT, 0);
 		goto out_unlock;
-	} else
+	} else {
 		tm = tcp_get_metrics(sk, dst, true);
-
+	}
 	if (!tm)
 		goto out_unlock;
 

--- a/net/xia/ppal_serval/serval_tcp_metrics.c
+++ b/net/xia/ppal_serval/serval_tcp_metrics.c
@@ -404,7 +404,8 @@ void serval_tcp_init_metrics(struct sock *sk)
 	val = tcp_metric_get_jiffies(tm, TCP_METRIC_RTTVAR);
 	if (val > tp->mdev) {
 		tp->mdev = val;
-		tp->mdev_max = tp->rttvar = max(tp->mdev, tcp_rto_min(sk));
+		tp->rttvar = max(tp->mdev, tcp_rto_min(sk));
+		tp->mdev_max = tp->rttvar;
 	}
 	rcu_read_unlock();
 
@@ -417,7 +418,9 @@ reset:
 		 * from the more aggressive 1sec to avoid more spurious
 		 * retransmission.
 		 */
-		tp->mdev = tp->mdev_max = tp->rttvar = TCP_TIMEOUT_FALLBACK;
+		tp->rttvar = TCP_TIMEOUT_FALLBACK;
+		tp->mdev_max = TCP_TIMEOUT_FALLBACK;
+		tp->mdev = TCP_TIMEOUT_FALLBACK;
 		tp->rto = TCP_TIMEOUT_FALLBACK;
 	}
 	/* Cut cwnd down to 1 per RFC5681 if SYN or SYN-ACK has been

--- a/net/xia/ppal_serval/serval_tcp_output.c
+++ b/net/xia/ppal_serval/serval_tcp_output.c
@@ -44,7 +44,6 @@ struct tcp_out_options {
 	__u8 *hash_location;	/* temporary pointer, overloaded */
 };
 
-
 /* SND.NXT, if window was not shrunk.
  * If window has been shrunk, what should we make? It is not clear at all.
  * Using SND.UNA we will fail to open window, SND.NXT is out of window. :-(
@@ -61,12 +60,10 @@ static inline __u32 serval_tcp_acceptable_seq(struct sock *sk)
 		return serval_tcp_wnd_end(tp);
 }
 
-
 static inline int serval_tcp_urg_mode(const struct serval_tcp_sock *tp)
 {
 	return tp->snd_una != tp->snd_up;
 }
-
 
 /* Calculate mss to advertise in SYN segment.
  * RFC1122, RFC1063, draft-ietf-tcpimpl-pmtud-01 state that:
@@ -221,7 +218,6 @@ static unsigned serval_tcp_synack_options(struct sock *sk,
 	return MAX_SERVAL_TCP_OPTION_SPACE - remaining;
 }
 
-
 /* Compute TCP options for ESTABLISHED sockets. This is not the
  * final wire format yet.
  */
@@ -352,7 +348,6 @@ static int serval_tcp_init_tso_segs(struct sock *sk, struct sk_buff *skb,
 	return tso_segs;
 }
 
-
 /* Determine a window scaling and initial window to offer.
  * Based on the assumption that the given amount of space
  * will be offered. Store the results in the tp structure.
@@ -410,6 +405,7 @@ void serval_tcp_select_initial_window(int __space, __u32 mss,
 	 */
 	if (mss > (1 << *rcv_wscale)) {
 		int init_cwnd = 4;
+
 		if (mss > 1460 * 3)
 			init_cwnd = 2;
 		else if (mss > 1460)
@@ -427,7 +423,6 @@ void serval_tcp_select_initial_window(int __space, __u32 mss,
 	/* Set the clamp no higher than max representable value */
 	(*window_clamp) = min(65535U << (*rcv_wscale), *window_clamp);
 }
-
 
 /* Chose a new window to advertise, update state in tcp_sock for the
  * socket, and return result with RFC1323 scaling applied.  The return
@@ -473,7 +468,6 @@ static u16 serval_tcp_select_window(struct sock *sk)
 	return new_win;
 }
 
-
 /* Congestion window validation. (RFC2861) */
 static void serval_tcp_cwnd_validate(struct sock *sk)
 {
@@ -493,7 +487,6 @@ static void serval_tcp_cwnd_validate(struct sock *sk)
 			serval_tcp_cwnd_application_limited(sk);
 	}
 }
-
 
 /* Returns the portion of skb which can be sent right away without
  * introducing MSS oddities to segment boundaries. In rare cases where
@@ -529,7 +522,6 @@ static unsigned int serval_tcp_mss_split_point(struct sock *sk,
 
 	return needed - needed % mss_now;
 }
-
 
 /* Can at least one segment of SKB be sent right now, according to the
  * congestion window rules?  If so, return how many segments are allowed.
@@ -612,6 +604,7 @@ static inline int serval_tcp_snd_wnd_test(struct serval_tcp_sock *tp,
 					  unsigned int cur_mss)
 {
 	u32 end_seq = TCP_SKB_CB(skb)->end_seq;
+
 	if (skb->len > cur_mss)
 		end_seq = TCP_SKB_CB(skb)->seq + cur_mss;
 	return !after(end_seq, serval_tcp_wnd_end(tp));
@@ -854,7 +847,6 @@ int serval_tcp_may_send_now(struct sock *sk)
 				     tp->nonagle : TCP_NAGLE_PUSH));
 }
 
-
 /* Remove acked data from a packet in the transmit queue. */
 int serval_tcp_trim_head(struct sock *sk, struct sk_buff *skb, u32 len)
 {
@@ -1044,7 +1036,6 @@ static int serval_tcp_transmit_skb(struct sock *sk, struct sk_buff *skb,
 	return net_xmit_eval(err);
 }
 
-
 /* Collapses two adjacent SKB's during retransmission. */
 static void serval_tcp_collapse_retrans(struct sock *sk, struct sk_buff *skb)
 {
@@ -1111,7 +1102,6 @@ static int serval_tcp_can_collapse(struct sock *sk, struct sk_buff *skb)
 
 	return 1;
 }
-
 
 /* Collapse packets in the retransmit queue to make to create
  * less packets on the wire. This is only done on retransmission.
@@ -1581,7 +1571,6 @@ static int serval_tcp_write_xmit(struct sock *sk, unsigned int mss_now,
 			limit = serval_tcp_mss_split_point(sk, skb, mss_now,
 							   cwnd_quota);
 
-
 		if (skb->len > limit &&
 		    unlikely(serval_tso_fragment(sk, skb, limit, mss_now, gfp)))
 			break;
@@ -1635,6 +1624,7 @@ void __serval_tcp_push_pending_frames(struct sock *sk, unsigned int cur_mss,
 void serval_tcp_push_one(struct sock *sk, unsigned int mss_now)
 {
 	struct sk_buff *skb = serval_tcp_send_head(sk);
+
 	BUG_ON(!skb || skb->len < mss_now);
 	serval_tcp_write_xmit(sk, mss_now, TCP_NAGLE_PUSH,
 			      1, sk->sk_allocation);
@@ -1831,6 +1821,7 @@ unsigned int serval_tcp_current_mss(struct sock *sk)
 
 	if (dst) {
 		u32 mtu = dst_mtu(dst);
+
 		if (mtu != tp->pmtu_cookie)
 			mss_now = serval_tcp_sync_mss(sk, mtu);
 	}
@@ -1844,6 +1835,7 @@ unsigned int serval_tcp_current_mss(struct sock *sk)
 	 */
 	if (header_len != tp->tcp_header_len) {
 		int delta = (int) header_len - tp->tcp_header_len;
+
 		mss_now -= delta;
 	}
 
@@ -1866,6 +1858,7 @@ static void serval_tcp_connect_init(struct sock *sk)
 	__u8 rcv_wscale;
 	struct dst_entry *dst = __sk_dst_get(sk);
 	unsigned int initrwnd = dst ? dst_metric(dst, RTAX_WINDOW) : 65535;
+
 	tp->tcp_header_len = sizeof(struct tcphdr);
 
 	if (tp->rx_opt.user_mss)

--- a/net/xia/ppal_serval/serval_tcp_output.c
+++ b/net/xia/ppal_serval/serval_tcp_output.c
@@ -318,7 +318,7 @@ static void serval_tcp_set_skb_tso_segs(struct sock *sk, struct sk_buff *skb,
 					unsigned int mss_now)
 {
 	if (1 /* Disable GSO */ || skb->len <= mss_now ||
-		1 /* !sk_can_gso(sk) */ || skb->ip_summed == CHECKSUM_NONE) {
+	    1 /* !sk_can_gso(sk) */ || skb->ip_summed == CHECKSUM_NONE) {
 		/* Avoid the costly divide in the normal
 		 * non-TSO case.
 		 */
@@ -733,7 +733,7 @@ static void __pskb_trim_head(struct sk_buff *skb, int len)
 			if (eat) {
 				skb_shinfo(skb)->frags[k].page_offset += eat;
 				skb_frag_size_sub(&skb_shinfo(skb)->frags[k],
-					eat);
+						  eat);
 				eat = 0;
 			}
 			k++;
@@ -1627,8 +1627,8 @@ void serval_tcp_push_one(struct sock *sk, unsigned int mss_now)
 {
 	struct sk_buff *skb = serval_tcp_send_head(sk);
 	BUG_ON(!skb || skb->len < mss_now);
-	serval_tcp_write_xmit(sk, mss_now,
-		TCP_NAGLE_PUSH, 1, sk->sk_allocation);
+	serval_tcp_write_xmit(sk, mss_now, TCP_NAGLE_PUSH,
+			      1, sk->sk_allocation);
 }
 
 /* This function returns the amount that we can raise the
@@ -1954,7 +1954,8 @@ int serval_tcp_connection_build_syn(struct sock *sk, struct sk_buff *skb)
 }
 
 int serval_tcp_connection_build_synack(struct sock *sk, struct dst_entry *dst,
-	struct request_sock *req, struct sk_buff *skb)
+				       struct request_sock *req,
+				       struct sk_buff *skb)
 {
 	struct serval_tcp_sock *tp = serval_tcp_sk(sk);
 	struct serval_tcp_request_sock *trsk = serval_tcp_rsk(req);
@@ -2408,8 +2409,9 @@ void serval_tcp_send_probe0(struct sock *sk)
 			tp->backoff++;
 		tp->probes_out++;
 		serval_tsk_reset_xmit_timer(sk, STSK_TIME_PROBE0,
-			min(tp->rto << tp->backoff, SERVAL_TCP_RTO_MAX),
-			SERVAL_TCP_RTO_MAX);
+					    min(tp->rto << tp->backoff,
+						SERVAL_TCP_RTO_MAX),
+					    SERVAL_TCP_RTO_MAX);
 	} else {
 		/* If packet was not sent due to local congestion,
 		 * do not backoff and do not remember icsk_probes_out.

--- a/net/xia/ppal_serval/serval_tcp_output.c
+++ b/net/xia/ppal_serval/serval_tcp_output.c
@@ -1504,7 +1504,8 @@ static int serval_tso_fragment(struct sock *sk, struct sk_buff *skb,
 	/* This packet was never sent out yet, so no SACK bits. */
 	TCP_SKB_CB(buff)->sacked = 0;
 
-	buff->ip_summed = skb->ip_summed = CHECKSUM_PARTIAL;
+	skb->ip_summed = CHECKSUM_PARTIAL;
+	buff->ip_summed = CHECKSUM_PARTIAL;
 	skb_split(skb, buff, len);
 
 	/* Fix up tso_factor for both original and new SKB.  */

--- a/net/xia/ppal_serval/serval_tcp_output.c
+++ b/net/xia/ppal_serval/serval_tcp_output.c
@@ -1384,8 +1384,8 @@ static int serval_tcp_mtu_probe(struct sock *sk)
 	}
 
 	/* We're allowed to probe. Build it now. */
-	if ((nskb = serval_sk_stream_alloc_skb(sk, probe_size, GFP_ATOMIC)) ==
-		NULL)
+	nskb = serval_sk_stream_alloc_skb(sk, probe_size, GFP_ATOMIC);
+	if (nskb == NULL)
 		return -1;
 	sk->sk_wmem_queued += nskb->truesize;
 	sk_mem_charge(sk, nskb->truesize);
@@ -2354,7 +2354,8 @@ int serval_tcp_write_wakeup(struct sock *sk)
 	if (sk->sk_state == TCP_CLOSE)
 		return -1;
 
-	if ((skb = serval_tcp_send_head(sk)) != NULL &&
+	skb = serval_tcp_send_head(sk);
+	if ((skb != NULL) &&
 	    before(TCP_SKB_CB(skb)->seq, serval_tcp_wnd_end(tp))) {
 		int err;
 		unsigned int mss = serval_tcp_current_mss(sk);

--- a/net/xia/ppal_serval/serval_tcp_output.c
+++ b/net/xia/ppal_serval/serval_tcp_output.c
@@ -1534,11 +1534,10 @@ static int serval_tcp_write_xmit(struct sock *sk, unsigned int mss_now,
 
 		result = serval_tcp_mtu_probe(sk);
 
-		if (!result) {
+		if (!result)
 			return 0;
-		} else if (result > 0) {
+		else if (result > 0)
 			sent_pkts = 1;
-		}
 	}
 
 	while ((skb = serval_tcp_send_head(sk))) {
@@ -2375,9 +2374,9 @@ int serval_tcp_write_wakeup(struct sock *sk)
 			TCP_SKB_CB(skb)->tcp_flags |= TCPH_PSH;
 			if (serval_tcp_fragment(sk, skb, seg_size, mss))
 				return -1;
-		} else if (!serval_tcp_skb_pcount(skb))
+		} else if (!serval_tcp_skb_pcount(skb)) {
 			serval_tcp_set_skb_tso_segs(sk, skb, mss);
-
+		}
 		TCP_SKB_CB(skb)->tcp_flags |= TCPH_PSH;
 		TCP_SKB_CB(skb)->when = tcp_time_stamp;
 		err = serval_tcp_transmit_skb(sk, skb, 1, GFP_ATOMIC);

--- a/net/xia/ppal_serval/serval_tcp_output.c
+++ b/net/xia/ppal_serval/serval_tcp_output.c
@@ -170,7 +170,8 @@ static unsigned serval_tcp_syn_options(struct sock *sk, struct sk_buff *skb,
 	 * receiver we won't recognize data packets as being full sized when we
 	 * should, and thus we won't abide by the delayed ACK rules correctly.
 	 * SACKs don't matter, we never delay an ACK when we have any of those
-	 * going out.  */
+	 * going out.
+	 */
 	opts->mss = serval_tcp_advertise_mss(sk);
 	remaining -= TCPOLEN_MSS_ALIGNED;
 
@@ -209,14 +210,14 @@ static unsigned serval_tcp_synack_options(struct sock *sk,
 		opts->options |= OPTION_WSCALE;
 		remaining -= TCPOLEN_WSCALE_ALIGNED;
 	}
-/*
+	/*
 	if (likely(trsk->tstamp_ok)) {
 		opts->options |= OPTION_TS;
 		opts->tsval = TCP_SKB_CB(skb)->when;
 		opts->tsecr = trsk->rsk.req.ts_recent;
 		remaining -= TCPOLEN_TSTAMP_ALIGNED;
 	}
-*/
+	*/
 	return MAX_SERVAL_TCP_OPTION_SPACE - remaining;
 }
 
@@ -229,8 +230,10 @@ static unsigned serval_tcp_established_options(struct sock *sk,
 					       struct tcp_out_options *opts,
 					       struct tcp_md5sig_key **md5)
 {
-	/* struct tcp_skb_cb *tcb = skb ? TCP_SKB_CB(skb) : NULL;
-	   struct serval_tcp_sock *tp = serval_tcp_sk(sk); */
+	/*
+	struct tcp_skb_cb *tcb = skb ? TCP_SKB_CB(skb) : NULL;
+	struct serval_tcp_sock *tp = serval_tcp_sk(sk);
+	*/
 	unsigned size = 0;
 
 	*md5 = NULL;
@@ -266,8 +269,9 @@ static void serval_tcp_event_new_data_sent(struct sock *sk, struct sk_buff *skb)
 					    SERVAL_TCP_RTO_MAX);
 }
 
-/* RFC2861. Reset CWND after idle period longer RTO to "restart window".
- * This is the first part of cwnd validation mechanism. */
+/* RFC2861. Reset CWND after idle period longer RTO to "restart window."
+ * This is the first part of cwnd validation mechanism.
+ */
 static void serval_tcp_cwnd_restart(struct sock *sk, struct dst_entry *dst)
 {
 	struct serval_tcp_sock *tp = serval_tcp_sk(sk);
@@ -614,7 +618,7 @@ static inline int serval_tcp_snd_wnd_test(struct serval_tcp_sock *tp,
 }
 
 /* This checks if the data bearing packet SKB (usually tcp_send_head(sk))
- * should be put on the wire right now.  If so, it returns the number of
+ * should be put on the wire right now. If so, it returns the number of
  * packets allowed by the congestion window.
  */
 static unsigned int serval_tcp_snd_test(struct sock *sk, struct sk_buff *skb,
@@ -881,7 +885,7 @@ int serval_tcp_trim_head(struct sock *sk, struct sk_buff *skb, u32 len)
 	return 0;
 }
 
-/* Calculate MSS. Not accounting for SACKs here.  */
+/* Calculate MSS. Not accounting for SACKs here. */
 int serval_tcp_mtu_to_mss(struct sock *sk, int pmtu)
 {
 	struct serval_tcp_sock *tp = serval_tcp_sk(sk);
@@ -889,25 +893,25 @@ int serval_tcp_mtu_to_mss(struct sock *sk, int pmtu)
 	int mss_now;
 
 	/* Calculate base mss without TCP options:
-	   It is MMS_S - sizeof(tcphdr) of rfc1122
+	 * It is MMS_S - sizeof(tcphdr) of rfc1122.
 	 */
 	mss_now = pmtu - ssk->af_ops->net_header_len - sizeof(struct tcphdr);
 
-	/* Clamp it (mss_clamp does not include tcp options) */
+	/* Clamp it (mss_clamp does not include tcp options). */
 	if (mss_now > tp->rx_opt.mss_clamp)
 		mss_now = tp->rx_opt.mss_clamp;
 
-	/* Then reserve room for full set of TCP options and 8 bytes of data */
+	/* Then reserve room for full set of TCP options and 8 bytes of data. */
 	if (mss_now < 48)
 		mss_now = 48;
 
-	/* Now subtract TCP options size, not including SACKs */
+	/* Now subtract TCP options size, not including SACKs. */
 	mss_now -= tp->tcp_header_len - sizeof(struct tcphdr);
 
 	return mss_now;
 }
 
-/* Inverse of above */
+/* Inverse of above. */
 int serval_tcp_mss_to_mtu(struct sock *sk, int mss)
 {
 	struct serval_tcp_sock *tp = serval_tcp_sk(sk);
@@ -988,7 +992,7 @@ static int serval_tcp_transmit_skb(struct sock *sk, struct sk_buff *skb,
 	th->check		= 0;
 	th->urg_ptr		= 0;
 
-	/* The urg_mode check is necessary during a below snd_una win probe */
+	/* The urg_mode check is necessary during a below snd_una win probe. */
 	if (unlikely(serval_tcp_urg_mode(tp) && before(tcb->seq, tp->snd_up))) {
 		if (before(tp->snd_up, tcb->seq + 0x10000)) {
 			th->urg_ptr = htons(tp->snd_up - tcb->seq);
@@ -1006,7 +1010,7 @@ static int serval_tcp_transmit_skb(struct sock *sk, struct sk_buff *skb,
 		TCP_ECN_send(sk, skb, tcp_header_size);
 	*/
 #ifdef CONFIG_TCP_MD5SIG_DISABLED
-	/* Calculate the MD5 hash, as we have all we need now */
+	/* Calculate the MD5 hash, as we have all we need now. */
 	if (md5) {
 		sk_nocaps_add(sk, NETIF_F_GSO_MASK);
 		tp->af_specific->calc_md5_hash(opts.hash_location,
@@ -1211,7 +1215,7 @@ int serval_tcp_retransmit_skb(struct sock *sk, struct sk_buff *skb)
 	serval_tcp_retrans_try_collapse(sk, skb, cur_mss);
 
 	/* Some Solaris stacks overoptimize and ignore the FIN on a
-	 * retransmit when old data is attached.  So strip it off
+	 * retransmit when old data is attached. So strip it off
 	 * since it is cheap to do so and saves bytes on the network.
 	 */
 	if (skb->len > 0 &&
@@ -1259,7 +1263,7 @@ int serval_tcp_retransmit_skb(struct sock *sk, struct sk_buff *skb)
 }
 
 /* Try to defer sending, if possible, in order to minimize the amount
- * of TSO splitting we do.  View it as a kind of TSO Nagle test.
+ * of TSO splitting we do. View it as a kind of TSO Nagle test.
  *
  * This algorithm is from John Heffner.
  */
@@ -1312,7 +1316,7 @@ static int serval_tcp_tso_should_defer(struct sock *sk, struct sk_buff *skb)
 			goto send_now;
 	} else {
 		/* Different approach, try not to defer past a single
-		 * ACK.  Receiver should ACK every other full sized
+		 * ACK. Receiver should ACK every other full sized
 		 * frame, so if we have space for more than 3 frames
 		 * then send now.
 		 */
@@ -1320,7 +1324,7 @@ static int serval_tcp_tso_should_defer(struct sock *sk, struct sk_buff *skb)
 			goto send_now;
 	}
 
-	/* Ok, it looks like it is advisable to defer.  */
+	/* Ok, it looks like it is advisable to defer. */
 	tp->tso_deferred = 1 | (jiffies << 1);
 
 	return 1;
@@ -1336,8 +1340,8 @@ send_now:
  * changes resulting in larger path MTUs.
  *
  * Returns 0 if we should wait to probe (no cwnd available),
- *	 1 if a probe was sent,
- *	 -1 otherwise
+ *	   1 if a probe was sent,
+ *	  -1 otherwise
  */
 static int serval_tcp_mtu_probe(struct sock *sk)
 {
@@ -1352,7 +1356,8 @@ static int serval_tcp_mtu_probe(struct sock *sk)
 	/* Not currently probing/verifying,
 	 * not in recovery,
 	 * have enough cwnd, and
-	 * not SACKing (the variable headers throw things off) */
+	 * not SACKing (the variable headers throw things off).
+	 */
 	if (!tp->tp_mtup.enabled ||
 	    tp->tp_mtup.probe_size ||
 	    tp->ca_state != TCP_CA_Open ||
@@ -1379,7 +1384,8 @@ static int serval_tcp_mtu_probe(struct sock *sk)
 		return 0;
 
 	/* Do we need to wait to drain cwnd? With none in flight,
-	   don't stall */
+	 * don't stall.
+	 */
 	if (serval_tcp_packets_in_flight(tp) + 2 > tp->snd_cwnd) {
 		if (!serval_tcp_packets_in_flight(tp))
 			return -1;
@@ -1387,7 +1393,7 @@ static int serval_tcp_mtu_probe(struct sock *sk)
 			return 0;
 	}
 
-	/* We're allowed to probe.  Build it now. */
+	/* We're allowed to probe. Build it now. */
 	if ((nskb = serval_sk_stream_alloc_skb(sk, probe_size, GFP_ATOMIC)) ==
 		NULL)
 		return -1;
@@ -1417,7 +1423,8 @@ static int serval_tcp_mtu_probe(struct sock *sk)
 
 		if (skb->len <= copy) {
 			/* We've eaten all the data from this skb.
-			 * Throw it away. */
+			 * Throw it away.
+			 */
 			TCP_SKB_CB(nskb)->tcp_flags |=
 				TCP_SKB_CB(skb)->tcp_flags;
 			serval_tcp_unlink_write_queue(skb, sk);
@@ -1445,12 +1452,14 @@ static int serval_tcp_mtu_probe(struct sock *sk)
 	}
 	serval_tcp_init_tso_segs(sk, nskb, nskb->len);
 
-	/* We're ready to send.  If this fails, the probe will
-	 * be resegmented into mss-sized pieces by tcp_write_xmit(). */
+	/* We're ready to send. If this fails, the probe will
+	 * be resegmented into mss-sized pieces by tcp_write_xmit().
+	 */
 	TCP_SKB_CB(nskb)->when = tcp_time_stamp;
 	if (!serval_tcp_transmit_skb(sk, nskb, 1, GFP_ATOMIC)) {
 		/* Decrement cwnd here because we are sending
-		 * effectively two packets. */
+		 * effectively two packets.
+		 */
 		tp->snd_cwnd--;
 		serval_tcp_event_new_data_sent(sk, nskb);
 
@@ -1831,7 +1840,8 @@ unsigned int serval_tcp_current_mss(struct sock *sk)
 	/* The mss_cache is sized based on tp->tcp_header_len, which assumes
 	 * some common options. If this is an odd packet (because we have SACK
 	 * blocks etc) then our calculated header_len will be different, and
-	 * we have to adjust mss_now correspondingly */
+	 * we have to adjust mss_now correspondingly.
+	 */
 	if (header_len != tp->tcp_header_len) {
 		int delta = (int) header_len - tp->tcp_header_len;
 		mss_now -= delta;
@@ -1967,14 +1977,15 @@ int serval_tcp_connection_build_synack(struct sock *sk, struct dst_entry *dst,
 
 	mss = dst_metric_advmss(dst);
 
-	if (req->rcv_wnd == 0) { /* ignored for retransmitted syns */
+	if (req->rcv_wnd == 0) { /* Ignored for retransmitted syns. */
 		__u8 rcv_wscale;
-		/* Set this up on the first call only */
+		/* Set this up on the first call only. */
 
 		req->window_clamp = tp->window_clamp ? :
 			dst_metric(dst, RTAX_WINDOW);
 		/* tcp_full_space because it is guaranteed to be the
-		 * first packet */
+		 * first packet.
+		 */
 		serval_tcp_select_initial_window(serval_tcp_full_space(sk),
 			mss - (trsk->tstamp_ok ? TCPOLEN_TSTAMP_ALIGNED : 0),
 			&req->rcv_wnd, &req->window_clamp, trsk->wscale_ok,
@@ -2077,7 +2088,7 @@ void serval_tcp_send_delayed_ack(struct sock *sk)
 		    (tp->tp_ack.pending & STSK_ACK_PUSHED))
 			max_ato = TCP_DELACK_MAX;
 
-		/* Slow path, intersegment interval is "high". */
+		/* Slow path, intersegment interval is "high." */
 
 		/* If some rtt estimate is known, use it to bound delayed ack.*/
 		if (tp->srtt) {
@@ -2090,7 +2101,7 @@ void serval_tcp_send_delayed_ack(struct sock *sk)
 		ato = min(ato, max_ato);
 	}
 
-	/* Stay within the limit we were given */
+	/* Stay within the limit we were given. */
 	timeout = jiffies + ato;
 
 	/* Use new timeout only if there wasn't a older one earlier. */
@@ -2178,7 +2189,7 @@ void serval_tcp_xmit_retransmit_queue(struct sock *sk)
 
 		if (skb == serval_tcp_send_head(sk))
 			break;
-		/* we could do better than to assign each time */
+		/* We could do better than to assign each time. */
 		if (hole == NULL)
 			tp->retransmit_skb_hint = skb;
 
@@ -2203,7 +2214,7 @@ begin_fwd:
 			tp->retransmit_high = last_lost;
 			if (!serval_tcp_can_forward_retransmit(sk))
 				break;
-			/* Backtrack if necessary to non-L'ed skb */
+			/* Backtrack if necessary to non-L'ed skb. */
 			if (hole != NULL) {
 				skb = hole;
 				hole = NULL;
@@ -2234,7 +2245,7 @@ begin_fwd:
 	}
 }
 
-/* Send a fin.  The caller locks the socket for us.  This cannot be
+/* Send a fin. The caller locks the socket for us. This cannot be
  * allowed to fail queueing a FIN frame under any circumstances.
  */
 void serval_tcp_send_fin(struct sock *sk)
@@ -2244,7 +2255,7 @@ void serval_tcp_send_fin(struct sock *sk)
 	int mss_now;
 
 	/* Optimization, tack on the FIN if we have a queue of
-	 * unsent frames.  But be careful about outgoing SACKS
+	 * unsent frames. But be careful about outgoing SACKS
 	 * and IP options.
 	 */
 	mss_now = serval_tcp_current_mss(sk);

--- a/net/xia/ppal_serval/serval_tcp_output.c
+++ b/net/xia/ppal_serval/serval_tcp_output.c
@@ -1833,7 +1833,7 @@ unsigned int serval_tcp_current_mss(struct sock *sk)
 	 * we have to adjust mss_now correspondingly.
 	 */
 	if (header_len != tp->tcp_header_len) {
-		int delta = (int) header_len - tp->tcp_header_len;
+		int delta = (int)header_len - tp->tcp_header_len;
 
 		mss_now -= delta;
 	}

--- a/net/xia/ppal_serval/serval_tcp_sock.c
+++ b/net/xia/ppal_serval/serval_tcp_sock.c
@@ -12,14 +12,17 @@ void serval_tsk_init_xmit_timers(struct sock *sk,
 		    (unsigned long)sk);
 	setup_timer(&tp->delack_timer, delack_handler, (unsigned long)sk);
 	setup_timer(&sk->sk_timer, keepalive_handler, (unsigned long)sk);
-	tp->pending = tp->tp_ack.pending = 0;
+	tp->tp_ack.pending = 0;
+	tp->pending = 0;
 }
 
 void serval_tsk_clear_xmit_timers(struct sock *sk)
 {
 	struct serval_tcp_sock *tp = serval_tcp_sk(sk);
 
-	tp->pending = tp->tp_ack.pending = tp->tp_ack.blocked = 0;
+	tp->tp_ack.blocked = 0;
+	tp->tp_ack.pending = 0;
+	tp->pending = 0;
 
 	sk_stop_timer(sk, &tp->retransmit_timer);
 	sk_stop_timer(sk, &tp->delack_timer);

--- a/net/xia/ppal_serval/serval_tcp_sock.c
+++ b/net/xia/ppal_serval/serval_tcp_sock.c
@@ -2,16 +2,15 @@
 #include "serval_tcp_sock.h"
 
 void serval_tsk_init_xmit_timers(struct sock *sk,
-			       void (*retransmit_handler)(unsigned long),
-			       void (*delack_handler)(unsigned long),
-			       void (*keepalive_handler)(unsigned long))
+				 void (*retransmit_handler)(unsigned long),
+				 void (*delack_handler)(unsigned long),
+				 void (*keepalive_handler)(unsigned long))
 {
 	struct serval_tcp_sock *tp = serval_tcp_sk(sk);
 
 	setup_timer(&tp->retransmit_timer, retransmit_handler,
-			(unsigned long)sk);
-	setup_timer(&tp->delack_timer, delack_handler,
-			(unsigned long)sk);
+		    (unsigned long)sk);
+	setup_timer(&tp->delack_timer, delack_handler, (unsigned long)sk);
 	setup_timer(&sk->sk_timer, keepalive_handler, (unsigned long)sk);
 	tp->pending = tp->tp_ack.pending = 0;
 }

--- a/net/xia/ppal_serval/serval_tcp_timer.c
+++ b/net/xia/ppal_serval/serval_tcp_timer.c
@@ -60,7 +60,8 @@ static int serval_tcp_out_of_resources(struct sock *sk, int do_reset)
 			printk(KERN_INFO "Out of socket memory\n");
 		*/
 		/* Catch exceptional cases, when connection requires reset.
-		 *      1. Last segment was sent recently. */
+		 *      1. Last segment was sent recently.
+		 */
 		if ((s32)(tcp_time_stamp - tp->lsndtime) <= TCP_TIMEWAIT_LEN ||
 		    /*  2. Window is closed. */
 		    (!tp->snd_wnd && !tp->packets_out))
@@ -70,8 +71,7 @@ static int serval_tcp_out_of_resources(struct sock *sk, int do_reset)
 
 		/* Too many orphans, TCP done! */
 		serval_sal_done(sk);
-		/* NET_INC_STATS_BH(sock_net(sk),
-			LINUX_MIB_TCPABORTONMEMORY); */
+		/* NET_INC_STATS_BH(sock_net(sk), LINUX_MIB_TCPABORTONMEMORY);*/
 		return 1;
 	}
 	return 0;
@@ -88,7 +88,8 @@ static int serval_tcp_orphan_retries(struct sock *sk, int alive)
 
 	/* However, if socket sent something recently, select some safe
 	 * number of retries. 8 corresponds to >100 seconds with minimal
-	 * RTO of 200msec. */
+	 * RTO of 200msec.
+	 */
 	if (retries == 0 && alive)
 		retries = 8;
 	return retries;
@@ -203,8 +204,7 @@ static void serval_tcp_delack_timer(unsigned long data)
 	if (sock_owned_by_user(sk)) {
 		/* Try again later. */
 		tp->tp_ack.blocked = 1;
-		/* NET_INC_STATS_BH(sock_net(sk),
-			LINUX_MIB_DELAYEDACKLOCKED); */
+		/* NET_INC_STATS_BH(sock_net(sk), LINUX_MIB_DELAYEDACKLOCKED);*/
 		sk_reset_timer(sk, &tp->delack_timer, jiffies + TCP_DELACK_MIN);
 		goto out_unlock;
 	}
@@ -223,8 +223,9 @@ static void serval_tcp_delack_timer(unsigned long data)
 	if (!skb_queue_empty(&tp->ucopy.prequeue)) {
 		struct sk_buff *skb;
 
-		/* NET_INC_STATS_BH(sock_net(sk),
-			LINUX_MIB_TCPSCHEDULERFAILED); */
+		/*
+		NET_INC_STATS_BH(sock_net(sk), LINUX_MIB_TCPSCHEDULERFAILED);
+		*/
 
 		while ((skb = __skb_dequeue(&tp->ucopy.prequeue)) != NULL)
 			sk_backlog_rcv(sk, skb);
@@ -299,9 +300,7 @@ static void serval_tcp_probe_timer(struct sock *sk)
 	}
 }
 
-/*
- *	The TCP retransmit timer.
- */
+/* The TCP retransmit timer. */
 
 void serval_tcp_retransmit_timer(struct sock *sk)
 {

--- a/net/xia/ppal_serval/serval_tcp_timer.c
+++ b/net/xia/ppal_serval/serval_tcp_timer.c
@@ -95,7 +95,6 @@ static int serval_tcp_orphan_retries(struct sock *sk, int alive)
 	return retries;
 }
 
-
 static void serval_tcp_mtu_probing(struct serval_tcp_sock *tp,
 				   struct sock *sk)
 {

--- a/net/xia/ppal_serval/serval_tcp_timer.c
+++ b/net/xia/ppal_serval/serval_tcp_timer.c
@@ -16,7 +16,8 @@ static void serval_tcp_keepalive_timer(unsigned long data);
 void serval_tcp_init_xmit_timers(struct sock *sk)
 {
 	serval_tsk_init_xmit_timers(sk,	serval_tcp_write_timer,
-		serval_tcp_delack_timer, serval_tcp_keepalive_timer);
+				    serval_tcp_delack_timer,
+				    serval_tcp_keepalive_timer);
 }
 
 static void serval_tcp_write_err(struct sock *sk)
@@ -46,7 +47,7 @@ static int serval_tcp_out_of_resources(struct sock *sk, int do_reset)
 	 * anything for long time, penalize it.
 	 */
 	if ((s32)(tcp_time_stamp - tp->lsndtime) > 2 * SERVAL_TCP_RTO_MAX ||
-		!do_reset)
+	    !do_reset)
 		shift++;
 
 	/* If some dubious ICMP arrived, penalize even more. */

--- a/net/xia/ppal_serval/serval_udp.c
+++ b/net/xia/ppal_serval/serval_udp.c
@@ -246,6 +246,7 @@ static int serval_udp_sendmsg(struct kiocb *iocb, struct sock *sk,
 
 	if (msg->msg_name) {
 		DECLARE_SOCKADDR(struct sockaddr_xia *, addr, msg->msg_name);
+
 		rc = check_sockaddr_xia((struct sockaddr *)addr,
 					msg->msg_namelen);
 		if (rc)

--- a/net/xia/ppal_serval/serval_udp.c
+++ b/net/xia/ppal_serval/serval_udp.c
@@ -271,7 +271,8 @@ static int serval_udp_sendmsg(struct kiocb *iocb, struct sock *sk,
 	if ((1 << sk->sk_state) & SALF_REQUEST) {
 		long timeo = sock_sndtimeo(sk, nonblock);
 		/* Wait for a connection to finish. */
-		if ((rc = sk_stream_wait_connect(sk, &timeo)) != 0)
+		rc = sk_stream_wait_connect(sk, &timeo);
+		if (rc != 0)
 			goto xdst;
 	}
 
@@ -608,9 +609,11 @@ static ssize_t serval_udp_do_sendpages(struct sock *sk, struct page **pages,
 	}
 
 	/* Wait for a connection to finish. */
-	if ((1 << sk->sk_state) & (SALF_REQUEST))
-		if ((err = sk_stream_wait_connect(sk, &timeo)) != 0)
+	if ((1 << sk->sk_state) & (SALF_REQUEST)) {
+		err = sk_stream_wait_connect(sk, &timeo);
+		if (err != 0)
 			goto out_err;
+	}
 
 	if (psize > 0xffff) {
 		/* Too much data. */

--- a/net/xia/ppal_serval/serval_udp.c
+++ b/net/xia/ppal_serval/serval_udp.c
@@ -535,7 +535,8 @@ ssize_t serval_udp_splice_read(struct socket *sock, loff_t *ppos,
 	if (unlikely(*ppos))
 		return -ESPIPE;
 
-	ret = spliced = 0;
+	spliced = 0;
+	ret = 0;
 
 	lock_sock(sk);
 

--- a/net/xia/ppal_serval/serval_udp.c
+++ b/net/xia/ppal_serval/serval_udp.c
@@ -423,9 +423,8 @@ out:
 }
 
 #if defined(ENABLE_SPLICE)
-/*
- *	UDP splice context
- */
+
+/* UDP splice context */
 
 struct udp_splice_state {
 	struct pipe_inode_info *pipe;

--- a/net/xia/ppal_serval/serval_udp.c
+++ b/net/xia/ppal_serval/serval_udp.c
@@ -543,9 +543,9 @@ ssize_t serval_udp_splice_read(struct socket *sock, loff_t *ppos,
 
 	while (tss.len) {
 		ret = __serval_udp_splice_read(sk, &tss);
-		if (ret < 0)
+		if (ret < 0) {
 			break;
-		else if (!ret) {
+		} else if (!ret) {
 			if (spliced)
 				break;
 			if (sock_flag(sk, SOCK_DONE))

--- a/net/xia/ppal_serval/serval_udp.c
+++ b/net/xia/ppal_serval/serval_udp.c
@@ -66,7 +66,8 @@ static int serval_udp_build_syn(struct sock *sk, struct sk_buff *skb)
 }
 
 static int serval_udp_build_synack(struct sock *sk, struct dst_entry *dst,
-	struct request_sock *req, struct sk_buff *skb)
+				   struct request_sock *req,
+				   struct sk_buff *skb)
 {
 	return serval_udp_build_syn(sk, skb);
 }
@@ -139,7 +140,8 @@ static int serval_udp_disconnect(struct sock *sk, int flags)
 }
 
 static int serval_udp_connection_request(struct sock *sk,
-	struct request_sock *rsk, struct sk_buff *skb)
+					 struct request_sock *rsk,
+					 struct sk_buff *skb)
 {
 	return 0;
 }
@@ -250,7 +252,7 @@ static int serval_udp_sendmsg(struct kiocb *iocb, struct sock *sk,
 	if (msg->msg_name) {
 		DECLARE_SOCKADDR(struct sockaddr_xia *, addr, msg->msg_name);
 		rc = check_sockaddr_xia((struct sockaddr *)addr,
-			msg->msg_namelen);
+					msg->msg_namelen);
 		if (rc)
 			return rc;
 		rc = check_type_of_all_sinks(addr, XIDTYPE_SRVCID);
@@ -261,7 +263,7 @@ static int serval_udp_sendmsg(struct kiocb *iocb, struct sock *sk,
 		dest_last_node = XIA_ENTRY_NODE_INDEX;
 
 		xdst = xip_mark_addr_and_get_dst(sock_net(sk), dest, dest_n,
-			&dest_last_node, 0);
+						 &dest_last_node, 0);
 		if (IS_ERR(xdst))
 			return PTR_ERR(xdst);
 	} else if (sk->sk_state != SAL_CONNECTED) {
@@ -278,7 +280,7 @@ static int serval_udp_sendmsg(struct kiocb *iocb, struct sock *sk,
 	}
 
 	skb = sock_alloc_send_skb(sk, sk->sk_prot->max_header + len,
-		nonblock, &rc);
+				  nonblock, &rc);
 	if (!skb)
 		goto xdst;
 	skb_reserve(skb, sk->sk_prot->max_header);
@@ -463,7 +465,7 @@ static int serval_udp_splice_data_recv(read_descriptor_t *rd_desc,
  *	  (although both would be easy to implement).
  */
 static int serval_udp_read_sock(struct sock *sk, read_descriptor_t *desc,
-	sk_read_actor_t recv_actor)
+				sk_read_actor_t recv_actor)
 {
 	struct sk_buff *skb;
 	int retval = 0;
@@ -674,7 +676,7 @@ out_err:
 }
 
 static int serval_udp_sendpage(struct sock *sk, struct page *page, int offset,
-	size_t size, int flags)
+			       size_t size, int flags)
 {
 	ssize_t res;
 

--- a/net/xia/ppal_u4id/main.c
+++ b/net/xia/ppal_u4id/main.c
@@ -8,9 +8,7 @@
 #include <net/xia_vxidty.h>
 #include <uapi/linux/udp.h>
 
-/*
- *	U4ID context
- */
+/* U4ID context */
 
 struct xip_u4id_ctx {
 	struct xip_ppal_ctx	ctx;
@@ -40,9 +38,7 @@ static inline struct xip_u4id_ctx *ctx_u4id(struct xip_ppal_ctx *ctx)
 
 static int my_vxt __read_mostly = -1;
 
-/*
- *	Local U4IDs
- */
+/* Local U4IDs */
 
 struct u4id_xid {
 	u32	ip_addr;
@@ -355,9 +351,7 @@ static const xia_ppal_all_rt_eops_t u4id_all_rt_eops = {
 	},
 };
 
-/*
- *	Network namespace
- */
+/* Network namespace */
 
 static struct xip_u4id_ctx *create_u4id_ctx(void)
 {
@@ -437,9 +431,7 @@ static struct pernet_operations u4id_net_ops __read_mostly = {
 	.exit = u4id_net_exit,
 };
 
-/*
- *	U4ID Routing
- */
+/* U4ID Routing */
 
 /* Tunnel destination information held in a DST entry. */
 struct u4id_tunnel_dest {

--- a/net/xia/ppal_u4id/main.c
+++ b/net/xia/ppal_u4id/main.c
@@ -56,6 +56,7 @@ struct u4id_xid {
 static inline int u4id_well_formed(const u8 *xid)
 {
 	struct u4id_xid *st_xid = (struct u4id_xid *)xid;
+
 	BUILD_BUG_ON(sizeof(struct u4id_xid) != XIA_XID_MAX);
 	return st_xid->ip_addr && st_xid->udp_port && !st_xid->zero1 &&
 		!st_xid->zero2 && !st_xid->zero3 && !st_xid->zero4;
@@ -256,6 +257,7 @@ static int local_delroute(struct xip_ppal_ctx *ctx,
 		 */
 
 		struct xip_u4id_ctx *u4id_ctx = ctx_u4id(ctx);
+
 		BUG_ON(!u4id_ctx->tunnel_sock);
 		RCU_INIT_POINTER(u4id_ctx->tunnel_sock, NULL);
 
@@ -339,6 +341,7 @@ nla_put_failure:
 static void local_free_u4id(struct fib_xid_table *xtbl, struct fib_xid *fxid)
 {
 	struct fib_xid_u4id_local *lu4id = fxid_lu4id(fxid);
+
 	BUG_ON(!lu4id->sock);
 	schedule_work(&lu4id->del_work);
 }
@@ -359,6 +362,7 @@ static const xia_ppal_all_rt_eops_t u4id_all_rt_eops = {
 static struct xip_u4id_ctx *create_u4id_ctx(void)
 {
 	struct xip_u4id_ctx *u4id_ctx = kmalloc(sizeof(*u4id_ctx), GFP_KERNEL);
+
 	if (!u4id_ctx)
 		return NULL;
 	xip_init_ppal_ctx(&u4id_ctx->ctx, XIDTYPE_U4ID);
@@ -446,6 +450,7 @@ struct u4id_tunnel_dest {
 static struct u4id_tunnel_dest *create_u4id_tunnel_dest(const u8 *xid)
 {
 	struct u4id_tunnel_dest *tunnel = kmalloc(sizeof(*tunnel), GFP_ATOMIC);
+
 	if (!tunnel)
 		return NULL;
 	tunnel->dest_ip_addr = *(__be32 *)xid;
@@ -515,6 +520,7 @@ static int handle_skb_to_ipv4(struct sock *tunnel_sk, struct sk_buff *skb,
 	rt = ip_route_output_flow(net, &fl4, tunnel_sk);
 	if (IS_ERR(rt)) {
 		int rc = PTR_ERR(rt);
+
 		if (rc == -ENETUNREACH)
 			IP_INC_STATS_BH(net, IPSTATS_MIB_OUTNOROUTES);
 		kfree_skb(skb);
@@ -598,6 +604,7 @@ static int u4id_deliver(struct xip_route_proc *rproc, struct net *net,
 	if (fxid) {
 		/* Reached tunnel destination; advance last node. */
 		struct fib_xid_u4id_local *lu4id = fxid_lu4id(fxid);
+
 		xdst->passthrough_action = XDA_DIG;
 		/* A local U4ID cannot be a sink. */
 		xdst->sink_action = XDA_ERROR;

--- a/net/xia/ppal_uni4id/main.c
+++ b/net/xia/ppal_uni4id/main.c
@@ -100,8 +100,8 @@ static const u8 uni_xid_prefix[] = {
 };
 
 static int uni4id_deliver(struct xip_route_proc *rproc, struct net *net,
-	const u8 *xid, struct xia_xid *next_xid, int anchor_index,
-	struct xip_dst *xdst)
+			  const u8 *xid, struct xia_xid *next_xid,
+			  int anchor_index, struct xip_dst *xdst)
 {
 	BUILD_BUG_ON(sizeof(uni_xid_prefix) != 16);
 	BUILD_BUG_ON(XIA_XID_MAX != 20);

--- a/net/xia/ppal_uni4id/main.c
+++ b/net/xia/ppal_uni4id/main.c
@@ -149,8 +149,7 @@ static struct xip_route_proc uni4id_rt_proc __read_mostly = {
 	.deliver = uni4id_deliver,
 };
 
-/*
- * xia_uni4id_init - this function is called when the module is loaded.
+/* xia_uni4id_init - this function is called when the module is loaded.
  * Returns zero if successfully loaded, nonzero otherwise.
  */
 static int __init xia_uni4id_init(void)
@@ -189,8 +188,7 @@ out:
 	return rc;
 }
 
-/*
- * xia_uni4id_exit - this function is called when the modlule is removed.
+/* xia_uni4id_exit - this function is called when the modlule is removed.
  */
 static void __exit xia_uni4id_exit(void)
 {

--- a/net/xia/ppal_uni4id/main.c
+++ b/net/xia/ppal_uni4id/main.c
@@ -121,16 +121,16 @@ static int uni4id_deliver(struct xip_route_proc *rproc, struct net *net,
 
 	/* Calculate next XID. */
 	next_xid->xid_type = XIDTYPE_U4ID;
-	next_xid->xid_id[ 0] = xid[16];
-	next_xid->xid_id[ 1] = xid[17];
-	next_xid->xid_id[ 2] = xid[18];
-	next_xid->xid_id[ 3] = xid[19];
-	next_xid->xid_id[ 4] = 0x35;
-	next_xid->xid_id[ 5] = 0xd5;
-	next_xid->xid_id[ 6] = 0x00;
-	next_xid->xid_id[ 7] = 0x00;
-	next_xid->xid_id[ 8] = 0x00;
-	next_xid->xid_id[ 9] = 0x00;
+	next_xid->xid_id[0]  = xid[16];
+	next_xid->xid_id[1]  = xid[17];
+	next_xid->xid_id[2]  = xid[18];
+	next_xid->xid_id[3]  = xid[19];
+	next_xid->xid_id[4]  = 0x35;
+	next_xid->xid_id[5]  = 0xd5;
+	next_xid->xid_id[6]  = 0x00;
+	next_xid->xid_id[7]  = 0x00;
+	next_xid->xid_id[8]  = 0x00;
+	next_xid->xid_id[9]  = 0x00;
 	next_xid->xid_id[10] = 0x00;
 	next_xid->xid_id[11] = 0x00;
 	next_xid->xid_id[12] = 0x00;

--- a/net/xia/ppal_uni4id/main.c
+++ b/net/xia/ppal_uni4id/main.c
@@ -8,9 +8,7 @@
 /* United 4ID Principal */
 #define XIDTYPE_UNI4ID (__cpu_to_be32(0x14))
 
-/*
- *	United 4ID context
- */
+/* United 4ID context */
 
 struct xip_uni4id_ctx {
 	struct xip_ppal_ctx	ctx;
@@ -27,9 +25,7 @@ static inline struct xip_uni4id_ctx *ctx_uni4id(struct xip_ppal_ctx *ctx)
 
 static int my_vxt __read_mostly = -1;
 
-/*
- *	Network namespace
- */
+/* Network namespace */
 
 static struct xip_uni4id_ctx *create_uni4id_ctx(void)
 {
@@ -82,9 +78,7 @@ static struct pernet_operations uni4id_net_ops __read_mostly = {
 	.exit = uni4id_net_exit,
 };
 
-/*
- *	United 4ID Routing
- */
+/* United 4ID Routing */
 
 /* XXX The following XID type should come from its
  * principal's header file once it is available.

--- a/net/xia/ppal_xdp/main.c
+++ b/net/xia/ppal_xdp/main.c
@@ -523,7 +523,7 @@ static int xdp_getsockopt(struct sock *sk, int level, int optname,
 		return -EFAULT;
 
 	lxdp = sk_lxdp(sk);
-	
+
 	switch (optname) {
 	case XDP_CORK:
 		val = lxdp->corkflag;
@@ -608,7 +608,7 @@ static int xdp_sendmsg(struct kiocb *iocb, struct sock *sk,
 		/* Open fast path for connected socket. */
 		connected = true;
 	}
-	
+
 	/* XXX Shouldn't one support sock_tx_timestamp and something similar
 	 * to IP's control messages (see ip_cmsg_send())?
 	 * See net/ipv4/udp.c:udp_sendmsg for an example.

--- a/net/xia/ppal_xdp/main.c
+++ b/net/xia/ppal_xdp/main.c
@@ -71,8 +71,8 @@ static inline struct fib_xid_xdp_local *sk_lxdp(struct sock *sk)
 }
 
 static int local_dump_xdp(struct fib_xid *fxid, struct fib_xid_table *xtbl,
-	struct xip_ppal_ctx *ctx, struct sk_buff *skb,
-	struct netlink_callback *cb)
+			  struct xip_ppal_ctx *ctx, struct sk_buff *skb,
+			  struct netlink_callback *cb)
 {
 	struct nlmsghdr *nlh;
 	u32 portid = NETLINK_CB(cb->skb).portid;
@@ -82,7 +82,7 @@ static int local_dump_xdp(struct fib_xid *fxid, struct fib_xid_table *xtbl,
 	const struct xia_sock *xia;
 
 	nlh = nlmsg_put(skb, portid, seq, RTM_NEWROUTE, sizeof(*rtm),
-		NLM_F_MULTI);
+			NLM_F_MULTI);
 	if (nlh == NULL)
 		return -EMSGSIZE;
 
@@ -119,7 +119,7 @@ static int local_dump_xdp(struct fib_xid *fxid, struct fib_xid_table *xtbl,
 		 * xia->xia_daddr and xia->xia_dnum?
 		 */
 		copy_n_and_shade_xia_addr_from_addr(&src, &xia->xia_daddr,
-			xia->xia_dnum);
+						    xia->xia_dnum);
 		if (unlikely(nla_put(skb, RTA_SRC, sizeof(src), &src)))
 			goto nla_put_failure;
 	}
@@ -185,7 +185,7 @@ static int __net_init xdp_net_init(struct net *net)
 	}
 
 	rc = init_xid_table(&xdp_ctx->ctx, net, &xia_main_lock_table,
-		xdp_all_rt_eops);
+			    xdp_all_rt_eops);
 	if (rc)
 		goto xdp_ctx;
 
@@ -273,8 +273,8 @@ static int local_output_output(struct sock *sk, struct sk_buff *skb)
 }
 
 static int xdp_deliver(struct xip_route_proc *rproc, struct net *net,
-	const u8 *xid, struct xia_xid *next_xid, int anchor_index,
-	struct xip_dst *xdst)
+		       const u8 *xid, struct xia_xid *next_xid,
+		       int anchor_index, struct xip_dst *xdst)
 {
 	struct xip_ppal_ctx *ctx;
 	struct fib_xid *fxid;
@@ -467,7 +467,7 @@ static int xdp_push_pending_frames(struct sock *sk)
 }
 
 static int xdp_setsockopt(struct sock *sk, int level, int optname,
-	char __user *optval, unsigned int optlen)
+			  char __user *optval, unsigned int optlen)
 {
 	struct fib_xid_xdp_local *lxdp;
 	int val, rc;
@@ -501,7 +501,7 @@ static int xdp_setsockopt(struct sock *sk, int level, int optname,
 }
 
 static int xdp_getsockopt(struct sock *sk, int level, int optname,
-	char __user *optval, int __user *optlen)
+			  char __user *optval, int __user *optlen)
 {
 	struct fib_xid_xdp_local *lxdp;
 	int val, len;
@@ -533,13 +533,13 @@ static int xdp_getsockopt(struct sock *sk, int level, int optname,
 }
 
 static int xdp_getfrag(void *from, char *to, int  offset, int len,
-	int odd, struct sk_buff *skb)
+		       int odd, struct sk_buff *skb)
 {
 	return memcpy_fromiovecend(to, (struct iovec *)from, offset, len);
 }
 
 static int xdp_sendmsg(struct kiocb *iocb, struct sock *sk,
-	struct msghdr *msg, size_t len)
+		       struct msghdr *msg, size_t len)
 {
 	struct fib_xid_xdp_local *lxdp = sk_lxdp(sk);
 	struct xia_sock *xia = &lxdp->xia_sk;
@@ -560,8 +560,9 @@ static int xdp_sendmsg(struct kiocb *iocb, struct sock *sk,
 		lock_sock(sk);
 		if (likely(lxdp->pending)) {
 			rc = xip_append_data(sk, xdp_getfrag, msg->msg_iov, len,
-				corkreq ? msg->msg_flags|MSG_MORE :
-					msg->msg_flags);
+					     corkreq ?
+					     msg->msg_flags|MSG_MORE :
+					     msg->msg_flags);
 			if (rc)
 				xdp_flush_pending_frames(sk);
 			else if (!corkreq)
@@ -582,7 +583,7 @@ static int xdp_sendmsg(struct kiocb *iocb, struct sock *sk,
 	if (msg->msg_name) {
 		DECLARE_SOCKADDR(struct sockaddr_xia *, addr, msg->msg_name);
 		rc = check_sockaddr_xia((struct sockaddr *)addr,
-			msg->msg_namelen);
+					msg->msg_namelen);
 		if (rc)
 			return rc;
 		rc = check_valid_nonempty_addr(addr);
@@ -617,7 +618,7 @@ static int xdp_sendmsg(struct kiocb *iocb, struct sock *sk,
 			dest_last_node = XIA_ENTRY_NODE_INDEX;
 		}
 		xdst = xip_mark_addr_and_get_dst(net, dest->s_row,
-			dest_n, &dest_last_node, 0);
+						 dest_n, &dest_last_node, 0);
 		if (IS_ERR(xdst))
 			return PTR_ERR(xdst);
 		if (connected) {
@@ -665,13 +666,13 @@ static int xdp_sendmsg(struct kiocb *iocb, struct sock *sk,
 		 */
 		release_sock(sk);
 		LIMIT_NETDEBUG(KERN_DEBUG pr_fmt("XDP %s(): cork app bug\n"),
-			__func__);
+			       __func__);
 		rc = -EINVAL;
 		goto xdst;
 	}
 
 	rc = xip_start_skb(sk, xdst, dest, dest_n, dest_last_node, 0,
-		corkreq ? msg->msg_flags|MSG_MORE : msg->msg_flags);
+			   corkreq ? msg->msg_flags|MSG_MORE : msg->msg_flags);
 	if (rc) {
 		release_sock(sk);
 		goto xdst;
@@ -681,7 +682,9 @@ static int xdp_sendmsg(struct kiocb *iocb, struct sock *sk,
 	lxdp->pending = true;
 
 	rc = xip_append_data(sk, xdp_getfrag, msg->msg_iov, len,
-		corkreq ? msg->msg_flags|MSG_MORE : msg->msg_flags);
+			     corkreq ?
+			     msg->msg_flags|MSG_MORE :
+			     msg->msg_flags);
 	if (rc)
 		xdp_flush_pending_frames(sk);
 	release_sock(sk);
@@ -694,7 +697,7 @@ out:
 
 /* If there is a packet there, return it, otherwise block. */
 static int xdp_recvmsg(struct kiocb *iocb, struct sock *sk, struct msghdr *msg,
-	size_t len, int noblock, int flags, int *addr_len)
+		       size_t len, int noblock, int flags, int *addr_len)
 {
 	DECLARE_SOCKADDR(struct sockaddr_xia *, sxia, msg->msg_name);
 	struct sk_buff *skb;
@@ -709,7 +712,7 @@ static int xdp_recvmsg(struct kiocb *iocb, struct sock *sk, struct msghdr *msg,
 		return xip_recv_error(sk, msg, len);
 
 	skb = __skb_recv_datagram(sk, flags | (noblock ? MSG_DONTWAIT : 0),
-		&peeked, &offset, &rc);
+				  &peeked, &offset, &rc);
 	if (!skb)
 		return rc;
 
@@ -730,7 +733,8 @@ static int xdp_recvmsg(struct kiocb *iocb, struct sock *sk, struct msghdr *msg,
 	if (sxia) {
 		const struct xiphdr *xiph = xip_hdr(skb);
 		copy_n_and_shade_sockaddr_xia(sxia,
-			&xiph->dst_addr[xiph->num_dst], xiph->num_src);
+					      &xiph->dst_addr[xiph->num_dst],
+					      xiph->num_src);
 	}
 
 	/* XXX Add support to control messages that return extra information

--- a/net/xia/ppal_xdp/main.c
+++ b/net/xia/ppal_xdp/main.c
@@ -135,6 +135,7 @@ nla_put_failure:
 static void local_free_xdp(struct fib_xid_table *xtbl, struct fib_xid *fxid)
 {
 	struct fib_xid_xdp_local *lxdp = fxid_lxdp(fxid);
+
 	xdst_free_anchor(&lxdp->anchor);
 	/* We do not sock_put(&lxdp->xia_sk.sk) because @fxid is released
 	 * before @lxdp, and we do not deallocate memory here because @fxid is
@@ -160,6 +161,7 @@ static const xia_ppal_all_rt_eops_t xdp_all_rt_eops = {
 static struct xip_xdp_ctx *create_xdp_ctx(void)
 {
 	struct xip_xdp_ctx *xdp_ctx = kmalloc(sizeof(*xdp_ctx), GFP_KERNEL);
+
 	if (!xdp_ctx)
 		return NULL;
 	xip_init_ppal_ctx(&xdp_ctx->ctx, XIDTYPE_XDP);
@@ -428,6 +430,7 @@ static int xdp_ioctl(struct sock *sk, int cmd, unsigned long arg)
 static int xdp_init(struct sock *sk)
 {
 	struct fib_xid_xdp_local *lxdp = sk_lxdp(sk);
+
 	xdst_init_anchor(&lxdp->anchor);
 	return 0;
 }
@@ -435,6 +438,7 @@ static int xdp_init(struct sock *sk)
 static void xdp_flush_pending_frames(struct sock *sk)
 {
 	struct fib_xid_xdp_local *lxdp = sk_lxdp(sk);
+
 	if (!lxdp->pending)
 		return;
 	lxdp->pending = false;
@@ -444,6 +448,7 @@ static void xdp_flush_pending_frames(struct sock *sk)
 static void xdp_destroy_sock(struct sock *sk)
 {
 	bool slow = lock_sock_fast(sk);
+
 	xdp_flush_pending_frames(sk);
 	unlock_sock_fast(sk, slow);
 }
@@ -462,6 +467,7 @@ static int xdp_push_pending_frames(struct sock *sk)
 	struct fib_xid_xdp_local *lxdp = sk_lxdp(sk);
 	struct sk_buff *skb = xip_finish_skb(sk);
 	int rc = !IS_ERR_OR_NULL(skb) ? xdp_send_skb(skb) : PTR_ERR(skb);
+
 	lxdp->pending = false;
 	return rc;
 }
@@ -582,6 +588,7 @@ static int xdp_sendmsg(struct kiocb *iocb, struct sock *sk,
 	/* Obtain destination address. */
 	if (msg->msg_name) {
 		DECLARE_SOCKADDR(struct sockaddr_xia *, addr, msg->msg_name);
+
 		rc = check_sockaddr_xia((struct sockaddr *)addr,
 					msg->msg_namelen);
 		if (rc)
@@ -611,6 +618,7 @@ static int xdp_sendmsg(struct kiocb *iocb, struct sock *sk,
 	xdst = connected ? dst_xdst(sk_dst_check(sk, 0)) : NULL;
 	if (!xdst) {
 		struct net *net = sock_net(sk);
+
 		memmove(&dest_stack, dest, sizeof(dest_stack));
 		dest = &dest_stack;
 		if (connected) {

--- a/net/xia/ppal_xdp/main.c
+++ b/net/xia/ppal_xdp/main.c
@@ -10,9 +10,8 @@
 #include <net/xia_vxidty.h>
 #include <net/xia_xdp.h>
 
-/*
- *	XDP context
- */
+/* XDP context */
+
 struct xip_xdp_ctx {
 	struct xip_ppal_ctx	ctx;
 
@@ -28,9 +27,7 @@ static inline struct xip_xdp_ctx *ctx_xdp(struct xip_ppal_ctx *ctx)
 
 static int my_vxt __read_mostly = -1;
 
-/*
- *	Local XDPs
- */
+/* Local XDPs */
 
 struct fib_xid_xdp_local {
 	/* Socket related fields. */
@@ -154,9 +151,7 @@ static const xia_ppal_all_rt_eops_t xdp_all_rt_eops = {
 	XIP_FIB_REDIRECT_MAIN,
 };
 
-/*
- *	Network namespace
- */
+/* Network namespace */
 
 static struct xip_xdp_ctx *create_xdp_ctx(void)
 {
@@ -214,9 +209,7 @@ static struct pernet_operations xdp_net_ops __read_mostly = {
 	.exit = xdp_net_exit,
 };
 
-/*
- *	XDP Routing
- */
+/* XDP Routing */
 
 static int local_input_input(struct sk_buff *skb)
 {
@@ -330,9 +323,7 @@ static struct xip_route_proc xdp_rt_proc __read_mostly = {
 	.deliver = xdp_deliver,
 };
 
-/*
- *	Socket API
- */
+/* Socket API */
 
 static void xdp_close(struct sock *sk, long timeout)
 {
@@ -385,8 +376,7 @@ static int xdp_disconnect(struct sock *sk, int flags)
 	return 0;
 }
 
-/**
- * first_packet_length	- return length of first packet in receive queue
+/* first_packet_length - return length of first packet in receive queue
  *	@sk: socket
  *
  *	Returns the length of found skb, or 0 if none is found.
@@ -920,9 +910,7 @@ static struct xia_socket_proc xdp_sock_proc __read_mostly = {
 	.procs[SOCK_DGRAM]	= &xdp_dgram,
 };
 
-/*
- *	Main
- */
+/* Main */
 
 static int __init xia_xdp_init(void)
 {

--- a/net/xia/ppal_xdp/main.c
+++ b/net/xia/ppal_xdp/main.c
@@ -968,9 +968,7 @@ out:
 	return rc;
 }
 
-/*
- * xia_ad_exit - this function is called when the modlule is removed.
- */
+/* xia_xdp_exit - this function is called when the modlule is removed. */
 static void __exit xia_xdp_exit(void)
 {
 	xia_del_socket_begin(&xdp_sock_proc);

--- a/net/xia/ppal_xdp/main.c
+++ b/net/xia/ppal_xdp/main.c
@@ -320,7 +320,6 @@ static int xdp_deliver(struct xip_route_proc *rproc, struct net *net,
 		fib_mrd_redirect(fxid, next_xid);
 		rcu_read_unlock();
 		return XRP_ACT_REDIRECT;
-
 	}
 	rcu_read_unlock();
 	BUG();
@@ -423,7 +422,6 @@ static int xdp_ioctl(struct sock *sk, int cmd, unsigned long arg)
 
 	default:
 		return -ENOIOCTLCMD;
-
 	}
 }
 

--- a/net/xia/ppal_zf/main.c
+++ b/net/xia/ppal_zf/main.c
@@ -531,8 +531,7 @@ static struct xip_route_proc zf_rt_proc __read_mostly = {
 	.deliver = zf_deliver,
 };
 
-/*
- * xia_zf_init - this function is called when the module is loaded.
+/* xia_zf_init - this function is called when the module is loaded.
  * Returns zero if successfully loaded, nonzero otherwise.
  */
 static int __init xia_zf_init(void)
@@ -571,9 +570,7 @@ out:
 	return rc;
 }
 
-/*
- * xia_zf_exit - this function is called when the modlule is removed.
- */
+/* xia_zf_exit - this function is called when the modlule is removed. */
 static void __exit xia_zf_exit(void)
 {
 	ppal_del_map(XIDTYPE_ZF);

--- a/net/xia/ppal_zf/main.c
+++ b/net/xia/ppal_zf/main.c
@@ -109,6 +109,7 @@ nla_put_failure:
 static void local_free_zf(struct fib_xid_table *xtbl, struct fib_xid *fxid)
 {
 	struct fib_xid_zf_local *lzf = fxid_lzf(fxid);
+
 	xdst_free_anchor(&lzf->anchor);
 	kfree(lzf);
 }
@@ -199,9 +200,9 @@ nla_put_failure:
 static void main_free_zf(struct fib_xid_table *xtbl, struct fib_xid *fxid)
 {
 	struct fib_xid_zf_main *mzf = fxid_mzf(fxid);
+
 	xdst_invalidate_redirect(xtbl_net(xtbl), XIDTYPE_ZF,
 				 mzf->common.fx_xid, &mzf->gw);
-
 	kfree(mzf);
 }
 
@@ -228,6 +229,7 @@ static const xia_ppal_all_rt_eops_t zf_all_rt_eops = {
 static struct xip_zf_ctx *create_zf_ctx(void)
 {
 	struct xip_zf_ctx *zf_ctx = kmalloc(sizeof(*zf_ctx), GFP_KERNEL);
+
 	if (!zf_ctx)
 		return NULL;
 	xip_init_ppal_ctx(&zf_ctx->ctx, XIDTYPE_ZF);
@@ -312,6 +314,7 @@ struct zf_dst_info {
 static struct zf_dst_info *create_zf_dst_info(const u8 *xid)
 {
 	struct zf_dst_info *info = kmalloc(sizeof(*info), GFP_ATOMIC);
+
 	if (!info)
 		return NULL;
 	memmove(info->xid, xid, XIA_XID_MAX);

--- a/net/xia/ppal_zf/main.c
+++ b/net/xia/ppal_zf/main.c
@@ -7,9 +7,7 @@
 /* zFilter principal */
 #define XIDTYPE_ZF (__cpu_to_be32(0x20))
 
-/*
- *	ZF context
- */
+/* ZF context */
 
 struct xip_zf_ctx {
 	struct xip_ppal_ctx	ctx;
@@ -27,9 +25,7 @@ static inline struct xip_zf_ctx *ctx_zf(struct xip_ppal_ctx *ctx)
 
 static int my_vxt __read_mostly = -1;
 
-/*
- *	Local ZFs
- */
+/* Local ZFs */
 
 struct fib_xid_zf_local {
 	struct fib_xid		common;
@@ -114,9 +110,7 @@ static void local_free_zf(struct fib_xid_table *xtbl, struct fib_xid *fxid)
 	kfree(lzf);
 }
 
-/*
- *	Main ZFs
- */
+/* Main ZFs */
 
 struct fib_xid_zf_main {
 	struct fib_xid		common;
@@ -222,9 +216,7 @@ static const xia_ppal_all_rt_eops_t zf_all_rt_eops = {
 	},
 };
 
-/*
- *	Network namespace
- */
+/* Network namespace */
 
 static struct xip_zf_ctx *create_zf_ctx(void)
 {
@@ -284,9 +276,7 @@ static struct pernet_operations zf_net_ops __read_mostly = {
 	.exit = zf_net_exit,
 };
 
-/*
- *	ZF Routing
- */
+/* ZF Routing */
 
 static int zf_match(const u8 *xid, const u8 *link_id)
 {

--- a/net/xia/route.c
+++ b/net/xia/route.c
@@ -1303,7 +1303,7 @@ int xip_route_with_a_redirect(struct net *net, struct sk_buff *skb,
 	       xiph->num_dst * sizeof(struct xia_row));
 
 	/* Overwrite previous XID. */
- 	ra_last_row = xip_last_row(redirected_addr.s_row,
+	ra_last_row = xip_last_row(redirected_addr.s_row,
 				   xiph->num_dst, xiph->last_node);
 	e = ra_last_row->s_edge.a[chosen_edge];
 	redirected_addr.s_row[e].s_xid = *next_xid;

--- a/net/xia/route.c
+++ b/net/xia/route.c
@@ -8,9 +8,7 @@
 #include <net/xia_vxidty.h>
 #include <net/xia_route.h>
 
-/*
- *	Route cache (DST)
- */
+/* Route cache (DST) */
 
 static struct dst_entry *xip_dst_check(struct dst_entry *dst, u32 cookie)
 {
@@ -527,9 +525,7 @@ static int xip_dst_gc(struct dst_ops *ops)
 	return dst_entries_get_slow(ops) > 2 * ops->gc_thresh;
 }
 
-/*
- *	DST Anchors
- */
+/* DST Anchors */
 
 static struct xia_lock_table anchor_locktbl __read_mostly;
 
@@ -798,9 +794,7 @@ drop:
 }
 EXPORT_SYMBOL_GPL(xdst_def_hop_limit_input_method);
 
-/*
- *	Principal routing
- */
+/* Principal routing */
 
 static DEFINE_MUTEX(ppal_mutex);
 static struct xip_route_proc *principals[XIP_MAX_XID_TYPES] __read_mostly;
@@ -1331,9 +1325,7 @@ int xip_route(struct net *net, struct sk_buff *skb, int input)
 }
 EXPORT_SYMBOL_GPL(xip_route);
 
-/*
- *	Handling XIP incoming packets
- */
+/* Handling XIP incoming packets */
 
 void skb_pull_xiphdr(struct sk_buff *skb)
 {
@@ -1410,9 +1402,7 @@ static struct packet_type xip_packet_type __read_mostly = {
 	/* XXX Implement GSO & GRO methods to improve performance. */
 };
 
-/*
- *	Initialization
- */
+/* Initialization */
 
 static int __net_init xip_route_net_init(struct net *net)
 {

--- a/net/xia/socket.c
+++ b/net/xia/socket.c
@@ -14,8 +14,7 @@
  * the work.
  */
 
-/*
- * The peer socket should always be NULL (or else). When we call this
+/* The peer socket should always be NULL (or else). When we call this
  * function we are destroying the object and from then on nobody
  * should refer to it.
  */

--- a/net/xia/socket.c
+++ b/net/xia/socket.c
@@ -144,7 +144,7 @@ out:
 EXPORT_SYMBOL_GPL(xia_bind);
 
 int xia_dgram_connect(struct socket *sock, struct sockaddr *uaddr,
-	int addr_len, int flags)
+		      int addr_len, int flags)
 {
 	struct sock *sk;
 	struct xia_sock *xia;
@@ -180,7 +180,7 @@ void xia_reset_dest(struct xia_sock *xia)
 EXPORT_SYMBOL_GPL(xia_reset_dest);
 
 void __xia_set_dest(struct xia_sock *xia, const struct xia_row *dest, int n,
-	int last_node, struct xip_dst *xdst)
+		    int last_node, struct xip_dst *xdst)
 {
 	xia->xia_dnum = n;
 	xia->xia_dlast_node = last_node;
@@ -200,7 +200,8 @@ int xia_set_dest(struct xia_sock *xia, const struct xia_row *dest, int n)
 	copy_n_and_shade_xia_addr(&xia->xia_daddr, dest, n);
 
 	xdst = xip_mark_addr_and_get_dst(sock_net(sk),
-		xia->xia_daddr.s_row, n, &xia->xia_dlast_node, 0);
+					 xia->xia_daddr.s_row, n,
+					 &xia->xia_dlast_node, 0);
 	if (IS_ERR(xdst))
 		return PTR_ERR(xdst);
 
@@ -211,7 +212,7 @@ int xia_set_dest(struct xia_sock *xia, const struct xia_row *dest, int n)
 EXPORT_SYMBOL_GPL(xia_set_dest);
 
 void copy_n_and_shade_xia_addr(struct xia_addr *dst,
-	const struct xia_row *rsrc, int n)
+			       const struct xia_row *rsrc, int n)
 {
 	struct xia_row *rdst = dst->s_row;
 
@@ -237,7 +238,7 @@ static inline void init_sockaddr_xia_but_addr(struct sockaddr_xia *sxia)
 }
 
 void copy_n_and_shade_sockaddr_xia(struct sockaddr_xia *dst,
-	const struct xia_row *rsrc, int n)
+				   const struct xia_row *rsrc, int n)
 {
 	init_sockaddr_xia_but_addr(dst);
 	copy_n_and_shade_xia_addr(&dst->sxia_addr, rsrc, n);
@@ -246,7 +247,7 @@ EXPORT_SYMBOL_GPL(copy_n_and_shade_sockaddr_xia);
 
 /* This does both peername and sockname. */
 int xia_getname(struct socket *sock, struct sockaddr *uaddr,
-	int *uaddr_len, int peer)
+		int *uaddr_len, int peer)
 {
 	struct xia_sock *xia = xia_sk(sock->sk);
 	DECLARE_SOCKADDR(struct sockaddr_xia *, sxia, uaddr);
@@ -255,12 +256,12 @@ int xia_getname(struct socket *sock, struct sockaddr *uaddr,
 		if (!xia->xia_daddr_set)
 			return -ENOTCONN;
 		copy_n_and_shade_sockaddr_xia_from_addr(sxia, &xia->xia_daddr,
-			xia->xia_dnum);
+							xia->xia_dnum);
 	} else {
 		if (!xia_sk_bound(xia))
 			return -ESNOTBOUND;
 		copy_n_and_shade_sockaddr_xia_from_addr(sxia, &xia->xia_saddr,
-			xia->xia_snum);
+							xia->xia_snum);
 	}
 
 	*uaddr_len = sizeof(*sxia);
@@ -322,7 +323,7 @@ int xia_shutdown(struct socket *sock, int how)
 EXPORT_SYMBOL_GPL(xia_shutdown);
 
 int xia_sendmsg(struct kiocb *iocb, struct socket *sock,
-	struct msghdr *msg, size_t size)
+		struct msghdr *msg, size_t size)
 {
 	struct sock *sk = sock->sk;
 
@@ -344,7 +345,7 @@ int xip_recv_error(struct sock *sk, struct msghdr *msg, int len)
 EXPORT_SYMBOL_GPL(xip_recv_error);
 
 int xia_recvmsg(struct kiocb *iocb, struct socket *sock,
-	struct msghdr *msg, size_t size, int flags)
+		struct msghdr *msg, size_t size, int flags)
 {
 	struct sock *sk = sock->sk;
 	int addr_len = 0;
@@ -362,7 +363,7 @@ int xia_recvmsg(struct kiocb *iocb, struct socket *sock,
 EXPORT_SYMBOL_GPL(xia_recvmsg);
 
 ssize_t xia_sendpage(struct socket *sock, struct page *page,
-	int offset, size_t size, int flags)
+		     int offset, size_t size, int flags)
 {
 	struct sock *sk = sock->sk;
 
@@ -525,7 +526,7 @@ static void xia_sock_destruct(struct sock *sk)
 }
 
 static int xia_create(struct net *net, struct socket *sock,
-		int protocol, int kern)
+		      int protocol, int kern)
 {
 	struct xia_socket_proc *sproc;
 	const struct xia_socket_type_proc *stproc;

--- a/net/xia/socket.c
+++ b/net/xia/socket.c
@@ -6,10 +6,9 @@
 #include <net/xia_vxidty.h>
 #include <net/xia_socket.h>
 
-/*
- *	Support functions for principals
- *
- * The routines beyond this point handle the behaviour of an AF_XIA
+/* Support functions for principals */
+
+/* The routines beyond this point handle the behaviour of an AF_XIA
  * socket object. Mostly it punts to the subprotocols of XIP to do
  * the work.
  */
@@ -380,9 +379,7 @@ ssize_t xia_sendpage(struct socket *sock, struct page *page,
 }
 EXPORT_SYMBOL_GPL(xia_sendpage);
 
-/*
- *	Principal-socket registering
- */
+/* Principal-socket registering */
 
 static DEFINE_MUTEX(ppal_mutex);
 static struct xia_socket_proc *principals[XIP_MAX_XID_TYPES];
@@ -500,9 +497,7 @@ void xia_del_socket_end(struct xia_socket_proc *sproc)
 }
 EXPORT_SYMBOL_GPL(xia_del_socket_end);
 
-/*
- *	Integration with socket API
- */
+/* Integration with socket API */
 
 static void xia_sock_destruct(struct sock *sk)
 {

--- a/net/xia/socket.c
+++ b/net/xia/socket.c
@@ -69,6 +69,7 @@ int check_type_of_all_sinks(struct sockaddr_xia *addr, xid_type_t ty)
 	/* Verify the type of all sinks. */
 	for (i = 0; i < n; i++) {
 		struct xia_row *row = &addr->sxia_addr.s_row[i];
+
 		if (is_it_a_sink(row, i, n) && row->s_xid.xid_type != ty)
 			return -EINVAL;
 	}
@@ -91,6 +92,7 @@ static int check_valid_single_sink(struct sockaddr_xia *addr)
 	i = n - 2;
 	while (i >= 0) {
 		__be32 all_edges = addr->sxia_addr.s_row[i].s_edge.i;
+
 		if (__be32_to_raw_cpu(all_edges) == XIA_EMPTY_EDGES)
 			return -EINVAL; /* There's more than a sink. */
 		i--;
@@ -393,6 +395,7 @@ static void unregister_protos(struct xia_socket_proc *sproc, int last_proc)
 		const struct xia_socket_type_proc *stproc =
 			sproc->procs[last_proc];
 		struct proto *prot;
+
 		last_proc--;
 		if (!stproc)
 			continue;

--- a/net/xia/vxidty.c
+++ b/net/xia/vxidty.c
@@ -22,7 +22,7 @@ static inline struct xip_vxt_entry *writable_current_map(void)
 }
 
 static inline struct xip_vxt_entry *get_entry_locked(struct xip_vxt_entry *map,
-	xid_type_t ty)
+						     xid_type_t ty)
 {
 	BUILD_BUG_ON_NOT_POWER_OF_2(XIP_VXT_TABLE_SIZE);
 	BUILD_BUG_ON(XIP_VXT_TABLE_SIZE < XIP_MAX_XID_TYPES);


### PR DESCRIPTION
These patches contain some style fixes to satisfy scripts/checkpatch.pl. There are still some errors, warnings, and checks reported by checkpatch, but in my opinion they are either false positives or inappropriate changes to make.

The only outstanding warnings that really _could_ be changed are the warnings related to the chunks of code in the Serval principal that are commented-out. However, many of these chunks are in place for future reference; they have comments like "use this code to determine how to do XXX." Other chunks that have to do with metrics that are currently commented out may be able to be removed; I don't know how valuable those pieces of code are, and whether it's worth removing them just to satisfy checkpatch.
