### PR TITLE
xia: fix struct net retrieval bug

### DIFF
--- a/net/xia/ppal_hid/main.c
+++ b/net/xia/ppal_hid/main.c
@@ -352,7 +352,7 @@ static int main_input_input(struct sk_buff *skb)
 	/* Decrease ttl after skb cow done. */
 	xiph->hop_limit--;
 
-	return dst_output(sock_net(skb->sk), skb->sk, skb);
+	return dst_output(xdst_net(xdst), skb->sk, skb);
 
 drop:
 	kfree_skb(skb);

--- a/net/xia/ppal_zf/main.c
+++ b/net/xia/ppal_zf/main.c
@@ -399,7 +399,7 @@ static int forward_local(struct iterate_arg *iarg,
 		 */
 		goto failed_to_forward;
 	}
-	rc = dst_output(sock_net(cpy_skb->sk), cpy_skb->sk, cpy_skb);
+	rc = dst_output(iarg->net, cpy_skb->sk, cpy_skb);
 	if (rc)
 		net_warn_ratelimited("XIA/ZF: can't forward a packet after digging the local ZF edge: %i\n",
 				     rc);
@@ -437,7 +437,7 @@ static int forward_main(struct iterate_arg *iarg, struct fib_xid_zf_main *mzf)
 		kfree_skb(cpy_skb);
 		return 0;
 	}
-	rc = dst_output(sock_net(cpy_skb->sk), cpy_skb->sk, cpy_skb);
+	rc = dst_output(iarg->net, cpy_skb->sk, cpy_skb);
 	if (rc)
 		net_warn_ratelimited("XIA/ZF: can't forward a packet after routing the main ZF edge: %i\n",
 				     rc);

--- a/net/xia/route.c
+++ b/net/xia/route.c
@@ -763,6 +763,8 @@ EXPORT_SYMBOL_GPL(xdst_invalidate_redirect);
 
 int xdst_def_hop_limit_input_method(struct sk_buff *skb)
 {
+	struct xip_dst *xdst;
+
 	/* XXX We should test that forwarding is enable per struct net.
 	 * See example in net/ipv6/ip6_output.c:ip6_forward.
 	 */
@@ -783,7 +785,9 @@ int xdst_def_hop_limit_input_method(struct sk_buff *skb)
 		xiph->hop_limit--;
 	}
 
-	return dst_output(sock_net(skb->sk), skb->sk, skb);
+	xdst = skb_xdst(skb);
+	BUG_ON(!xdst);
+	return dst_output(xdst_net(xdst), skb->sk, skb);
 
 drop:
 	kfree_skb(skb);


### PR DESCRIPTION
Some XIA functions handle packets that come from the network, so
there is no associated socket. In these cases, skb->sk is NULL,
so it cannot be used in calls to dst_output() since that function
assumes the given socket is not NULL.

This commit fixes these bugs introduced in commit:
  1695676
